### PR TITLE
Ring Transposes finalised

### DIFF
--- a/include/dns_const_mpi.h
+++ b/include/dns_const_mpi.h
@@ -25,6 +25,11 @@
 
 #define DNS_MPI_I_MAXTYPES  6
 
+! Control of MPI Transpositions 
+#define DNS_MPI_TRP_NONE         0
+#define DNS_MPI_TRP_ASYNCHRONOUS 1 
+#define DNS_MPI_TRP_SENDRECV     2
+
 #define MPIO_SUBARRAY_VISUALS_XOY  1
 #define MPIO_SUBARRAY_VISUALS_ZOY  2
 #define MPIO_SUBARRAY_VISUALS_XOZ  3

--- a/modules/dns_mpi.f90
+++ b/modules/dns_mpi.f90
@@ -20,7 +20,8 @@ MODULE DNS_MPI
   TINTEGER, DIMENSION(  :), ALLOCATABLE :: ims_size_i
   TINTEGER, DIMENSION(:,:), ALLOCATABLE :: ims_ds_i, ims_dr_i
   INTEGER,  DIMENSION(:,:), ALLOCATABLE :: ims_ts_i, ims_tr_i
-  INTEGER(KIND=4), DIMENSION(:), ALLOCATABLE :: ims_plan_trps_i, ims_plan_trpr_i 
+  TINTEGER, DIMENSION(:),   ALLOCATABLE :: ims_plan_trps_i, ims_plan_trpr_i  
+  TINTEGER                              :: ims_trp_mode_i
 
 
 !  INTEGER,  DIMENSION(:  ), ALLOCATABLE :: ims_map_j
@@ -32,7 +33,8 @@ MODULE DNS_MPI
   TINTEGER, DIMENSION(  :), ALLOCATABLE :: ims_size_k
   TINTEGER, DIMENSION(:,:), ALLOCATABLE :: ims_ds_k, ims_dr_k
   INTEGER,  DIMENSION(:,:), ALLOCATABLE :: ims_ts_k, ims_tr_k
-  INTEGER(KIND=4), DIMENSION(:), ALLOCATABLE :: ims_plan_trps_k, ims_plan_trpr_k
+  TINTEGER, DIMENSION(:),   ALLOCATABLE :: ims_plan_trps_k, ims_plan_trpr_k
+  TINTEGER                              :: ims_trp_mode_k 
 
   TINTEGER, DIMENSION(:),   ALLOCATABLE :: ims_size_p ! Particle data  
 

--- a/modules/dns_mpi.f90
+++ b/modules/dns_mpi.f90
@@ -20,6 +20,8 @@ MODULE DNS_MPI
   TINTEGER, DIMENSION(  :), ALLOCATABLE :: ims_size_i
   TINTEGER, DIMENSION(:,:), ALLOCATABLE :: ims_ds_i, ims_dr_i
   INTEGER,  DIMENSION(:,:), ALLOCATABLE :: ims_ts_i, ims_tr_i
+  INTEGER(KIND=4), DIMENSION(:), ALLOCATABLE :: ims_plan_trps_i, ims_plan_trpr_i 
+
 
 !  INTEGER,  DIMENSION(:  ), ALLOCATABLE :: ims_map_j
 !  TINTEGER, DIMENSION(  :), ALLOCATABLE :: ims_size_j
@@ -30,6 +32,7 @@ MODULE DNS_MPI
   TINTEGER, DIMENSION(  :), ALLOCATABLE :: ims_size_k
   TINTEGER, DIMENSION(:,:), ALLOCATABLE :: ims_ds_k, ims_dr_k
   INTEGER,  DIMENSION(:,:), ALLOCATABLE :: ims_ts_k, ims_tr_k
+  INTEGER(KIND=4), DIMENSION(:), ALLOCATABLE :: ims_plan_trps_k, ims_plan_trpr_k
 
   TINTEGER, DIMENSION(:),   ALLOCATABLE :: ims_size_p ! Particle data  
 

--- a/mpi/dns_mpi_trpb.f90
+++ b/mpi/dns_mpi_trpb.f90
@@ -1,4 +1,5 @@
 #include "types.h"
+#include "dns_const_mpi.h" 
 
 !########################################################################
 !# HISTORY
@@ -9,6 +10,9 @@
 !#              Debugged
 !# 2015/03/14 - J.P. Mellado
 !#              Using local communicator
+!# 2019/05/23 - C. Ansorge
+!#              Ring-shape transposes 
+!#              Control to switch between synchronous and sendrecv implementation
 !#
 !########################################################################
 !# DESCRIPTION
@@ -21,7 +25,9 @@ SUBROUTINE DNS_MPI_TRPB_K(b, a, dsend, drecv, tsend, trecv)
   USE DNS_MPI, ONLY : ims_time_trans
   USE DNS_MPI, ONLY : ims_npro_k, ims_pro_k
   USE DNS_MPI, ONLY : ims_comm_z
-  USE DNS_MPI, ONLY : ims_tag, ims_err
+  USE DNS_MPI, ONLY : ims_tag, ims_err 
+  USE DNS_MPI, ONLY : ims_plan_trps_k, ims_plan_trpr_k 
+  USE DNS_MPI, ONLY : ims_trp_mode_k 
 
   IMPLICIT NONE
   
@@ -33,7 +39,7 @@ SUBROUTINE DNS_MPI_TRPB_K(b, a, dsend, drecv, tsend, trecv)
   INTEGER,  DIMENSION(ims_npro_k), INTENT(IN)  :: tsend, trecv
   
 ! -----------------------------------------------------------------------
-  TINTEGER n, l
+  TINTEGER l,m,ns,nr,ips,ipr
   INTEGER status(MPI_STATUS_SIZE,2*ims_npro_k)
   INTEGER mpireq(                2*ims_npro_k)
   INTEGER ip
@@ -47,30 +53,25 @@ SUBROUTINE DNS_MPI_TRPB_K(b, a, dsend, drecv, tsend, trecv)
   time_loc_1 = MPI_WTIME()
 #endif
 
-! #######################################################################
-! Same processor
-! #######################################################################
-  ip = ims_pro_k; n = ip + 1
-  CALL MPI_ISEND(b(drecv(n)+1), 1, trecv(n), ip, ims_tag, ims_comm_z, mpireq(1), ims_err)
-  CALL MPI_IRECV(a(dsend(n)+1), 1, tsend(n), ip, ims_tag, ims_comm_z, mpireq(2), ims_err)
-
-  CALL MPI_WAITALL(2, mpireq, status, ims_err)
-
-! #######################################################################
-! Different processors
-! #######################################################################
-  l = 2
-  DO n = 1,ims_npro_k
-     ip = n - 1
-     IF ( ip .NE. ims_pro_k ) THEN
+  l = 0
+  DO m=1,ims_npro_k 
+     ns=ims_plan_trps_k(m)+1; ips=ns-1
+     nr=ims_plan_trpr_k(m)+1; ipr=nr-1  
+     IF ( ims_trp_mode_k .EQ. DNS_MPI_TRP_ASYNCHRONOUS ) THEN 
         l = l + 1
-        CALL MPI_ISEND(b(drecv(n)+1), 1, trecv(n), ip, ims_tag, ims_comm_z, mpireq(l), ims_err)
+        CALL MPI_ISEND(b(drecv(nr)+1), 1, trecv(nr), ipr, ims_tag, ims_comm_z, mpireq(l), ims_err)
         l = l + 1
-        CALL MPI_IRECV(a(dsend(n)+1), 1, tsend(n), ip, ims_tag, ims_comm_z, mpireq(l), ims_err)
+        CALL MPI_IRECV(a(dsend(ns)+1), 1, tsend(ns), ips, ims_tag, ims_comm_z, mpireq(l), ims_err) 
+     ELSEIF ( ims_trp_mode_k .EQ. DNS_MPI_TRP_SENDRECV ) THEN 
+        CALL MPI_SENDRECV(& 
+             b(drecv(nr)+1), 1, trecv(nr), ipr, ims_tag,  & 
+             a(dsend(ns)+1), 1, tsend(ns), ips, ims_tag, ims_comm_z, status(1,m), ims_err)   
+     ELSE; CONTINUE   ! No transpose
      ENDIF
   ENDDO
 
-  CALL MPI_WAITALL(ims_npro_k*2-2, mpireq(3:), status(:,3:), ims_err)
+  IF ( ims_trp_mode_k .EQ. DNS_MPI_TRP_ASYNCHRONOUS ) & 
+       CALL MPI_WAITALL(ims_npro_k*2, mpireq(1:), status(1,1), ims_err)
 
   CALL DNS_MPI_TAGUPDT
 
@@ -89,7 +90,8 @@ SUBROUTINE DNS_MPI_TRPB_I(b, a, dsend, drecv, tsend, trecv)
   USE DNS_MPI, ONLY : ims_npro_i, ims_pro_i
   USE DNS_MPI, ONLY : ims_comm_x
   USE DNS_MPI, ONLY : ims_tag, ims_err
-
+  USE DNS_MPI, ONLY : ims_trp_mode_i
+  USE DNS_MPI, ONLY : ims_plan_trps_i, ims_plan_trpr_i
   IMPLICIT NONE
   
 #include "mpif.h"
@@ -100,35 +102,30 @@ SUBROUTINE DNS_MPI_TRPB_I(b, a, dsend, drecv, tsend, trecv)
   INTEGER,  DIMENSION(ims_npro_i), INTENT(IN)  :: tsend, trecv ! types
   
 ! -----------------------------------------------------------------------
-  TINTEGER n, l
+  TINTEGER l,m,ns,nr,ips,ipr
   INTEGER status(MPI_STATUS_SIZE,2*ims_npro_i)
   INTEGER mpireq(                2*ims_npro_i)
   INTEGER ip
 
-! #######################################################################
-! Same processor
-! #######################################################################
-  ip = ims_pro_i; n = ip + 1
-  CALL MPI_ISEND(b(drecv(n)+1), 1, trecv(n), ip, ims_tag, ims_comm_x, mpireq(1), ims_err)
-  CALL MPI_IRECV(a(dsend(n)+1), 1, tsend(n), ip, ims_tag, ims_comm_x, mpireq(2), ims_err)
-
-  CALL MPI_WAITALL(2, mpireq, status, ims_err)
-
-! #######################################################################
-! Different processors
-! #######################################################################
-  l = 2
-  DO n = 1,ims_npro_i
-     ip = n-1
-     IF ( ip .NE. ims_pro_i ) THEN
+  l = 0
+  DO m = 1,ims_npro_i
+     ns=ims_plan_trps_i(m)+1; ips=ns-1
+     nr=ims_plan_trpr_i(m)+1; ipr=nr-1  
+     IF ( ims_trp_mode_i .EQ. DNS_MPI_TRP_ASYNCHRONOUS ) THEN 
         l = l + 1
-        CALL MPI_ISEND(b(drecv(n)+1), 1, trecv(n), ip, ims_tag, ims_comm_x, mpireq(l), ims_err)
+        CALL MPI_ISEND(b(drecv(nr)+1), 1, trecv(nr), ipr, ims_tag, ims_comm_x, mpireq(l), ims_err)
         l = l + 1
-        CALL MPI_IRECV(a(dsend(n)+1), 1, tsend(n), ip, ims_tag, ims_comm_x, mpireq(l), ims_err)
+        CALL MPI_IRECV(a(dsend(ns)+1), 1, tsend(ns), ips, ims_tag, ims_comm_x, mpireq(l), ims_err)
+     ELSEIF ( ims_trp_mode_i .EQ. DNS_MPI_TRP_SENDRECV ) THEN 
+        CALL MPI_SENDRECV(& 
+             b(drecv(nr)+1), 1, trecv(nr), ipr, ims_tag,&
+             a(dsend(ns)+1), 1, tsend(ns), ips, ims_tag, ims_comm_x, status(1,m), ims_err)  
+     ELSE; CONTINUE    ! No transpose
      ENDIF
   ENDDO
 
-  CALL MPI_WAITALL(ims_npro_i*2-2, mpireq(3:), status(:,3:), ims_err)
+  IF ( ims_trp_mode_i .EQ. DNS_MPI_TRP_ASYNCHRONOUS ) & 
+       CALL MPI_WAITALL(ims_npro_i*2, mpireq(1:), status(1,1), ims_err) 
 
   CALL DNS_MPI_TAGUPDT
 

--- a/tools/dns/dns_read_local.f90
+++ b/tools/dns/dns_read_local.f90
@@ -20,8 +20,6 @@ SUBROUTINE DNS_READ_LOCAL(inifile)
   USE BOUNDARY_INFLOW
   USE STATISTICS
 
-  USE DNS_MPI, ONLY :  ims_pro
-  
   IMPLICIT NONE
 
 #include "integers.h"
@@ -113,9 +111,7 @@ SUBROUTINE DNS_READ_LOCAL(inifile)
      CALL IO_WRITE_ASCII(efile, 'DNS_READ_LOCAL. Wrong ComModeKTranspose option.')
      CALL DNS_STOP(DNS_ERROR_OPTION) 
   ENDIF
-
 #endif 
-
 
 ! ###################################################################
 ! Iteration Section

--- a/tools/dns/dns_read_local.f90
+++ b/tools/dns/dns_read_local.f90
@@ -103,7 +103,7 @@ SUBROUTINE DNS_READ_LOCAL(inifile)
      CALL DNS_STOP(DNS_ERROR_OPTION) 
   ENDIF
 
-  CALL SCANINICHAR(bakfile,inifile, 'Main', 'ComModeKTranspose', 'asynchronous',sRes)
+  CALL SCANINICHAR(bakfile,inifile, 'Main', 'ComModeKTranspose', 'sendrecv',sRes)
   IF     ( TRIM(ADJUSTL(sRes)) .eq. 'none')         THEN; ims_trp_mode_k = DNS_MPI_TRP_NONE
   ELSEIF ( TRIM(ADJUSTL(sRes)) .eq. 'asynchronous') THEN; ims_trp_mode_k = DNS_MPI_TRP_ASYNCHRONOUS
   ELSEIF ( TRIM(ADJUSTL(sRes)) .eq. 'sendrecv'    ) THEN; ims_trp_mode_k = DNS_MPI_TRP_SENDRECV


### PR DESCRIPTION
The ring-shaped transposes are now implemented and can be controlled through the following options in `dns.ini` (only read if the compiler flag `USE_MPI` is set):

```
ComModeITranspose=<none,sendrecv,asynchronous> ! default: sendrecv 
ComModeKTranspose=<none,sendrecv,asynchronous> ! default: sendrecv
```
- `none` switches off the transposes (may be useful at some point for debugging the MPI or performance testing)
- `sendrecv` is a fully blocking point-to-point version based on `MPISendRecv`
- `asynchronous` is an `Isend / Irecv` implementation as it used to be.

New global variables were added to the module dns_mpi.mod

-`ims_trp_mode_i`, `ims_trp_mode_k` carry the above option for the transpose
-`ims_plan_trp<s,r>_<i,k>` carry the order-of-execution plans to ascertain the transposes are carried out in ring-shape; they are defined in `dns_mpi_initialize`

The difference in runtime between the `sendrecv`/`asynchronous` combinations for I and K transposes is very small with a tendency for the combination of asynchronous in both direction to be the slowest. The version `sendrecv`/`sendrecv` has least MPI complexity and overhead is therefore chosen as default as it should yield maximum stability and portability.

Overall, I get a 15-20% speed-up for the current case using 3840x960x7680 grid points on 96 nodes, but we have to keep in mind that measurements on juwels are still highly problematic.