### PR TITLE
Use Intel MKL for dns_transpose on juwels

### DIFF
--- a/config/juwels.cmake
+++ b/config/juwels.cmake
@@ -53,7 +53,7 @@ if ( NOT CMAKE_BUILD_TYPE )
   set(CMAKE_BUILD_TYPE RELEASE)  
 endif() 
 
-add_definitions(-DUSE_FFTW -DUSE_BLAS) 
+add_definitions(-DUSE_FFTW -DUSE_BLAS -DUSE_MKL) 
 
 #set(FFTW_INCLUDE_DIR "/gpfs/software/juwels/stages/2018a/software/FFTW/3.3.7-ipsmpi-2018a/include/")
 #set(FFTW_LIB         "/gpfs/software/juwels/stages/2018a/software/FFTW/3.3.7-ipsmpi-2018a/lib/libfftw3.a")

--- a/utils/dns_transpose.f90
+++ b/utils/dns_transpose.f90
@@ -40,6 +40,9 @@ SUBROUTINE DNS_TRANSPOSE(a, nra, nca, ma, b, mb)
   TINTEGER k,j,jj,kk
   TINTEGER last_k, last_j
 
+#ifdef USE_MKL 
+  CALL MKL_DOMATCOPY('c','t',nra,nca,C_1_R,a,ma,b,mb)
+#else #use own implementation
 !$omp parallel default(none) &
 !$omp private(k,j,jj,kk,srt,end,siz,last_k,last_j) &
 !$omp shared(a,b,nca,nra)
@@ -75,6 +78,7 @@ SUBROUTINE DNS_TRANSPOSE(a, nra, nca, ma, b, mb)
 
 !$omp end parallel 
 
+#endif 
   RETURN
 END SUBROUTINE DNS_TRANSPOSE
 


### PR DESCRIPTION
The computing centre in Cologne is using our code as a benchmark for procurement of their new TIER-1 system CHEOPS-2. 

When creating the benchmark, they found that using MKL for the transposition is saves up to 10% runtime in total(!) when the problem really uses all the memory on their system. I checked for the examples on juwels, and performance benefit was positive, but smaller (1-2%). 

Cann always be switched off by unsetting -DUSE_MKL in config/juwels.cmake but it makes sense that intel knows best how to transpose data on their own CPUs…