### PR TITLE
old variable "group" in netCDF

### DIFF
--- a/src/averages/avg.f90
+++ b/src/averages/avg.f90
@@ -34,10 +34,10 @@ SUBROUTINE AVG_N_XZ(fname, itime,rtime, nx,ny,nz, nv,nm, vars, igate,gate, y, av
   ! -------------------------------------------------------------------
   TINTEGER j,iv,im
   TREAL AVG1V2D, AVG1V2D1G, moments(nm)
-  CHARACTER(LEN=32) varname(nm)
+  CHARACTER(LEN=32) varname(nm), vargroup(nm) 
 
-#ifndef USE_NETCDF
   CHARACTER*32 str
+#ifndef USE_NETCDF
   CHARACTER*1024 line1
   CHARACTER*2048 line2
 #ifdef USE_MPI
@@ -68,13 +68,18 @@ SUBROUTINE AVG_N_XZ(fname, itime,rtime, nx,ny,nz, nv,nm, vars, igate,gate, y, av
   DO iv = 1,nv
     im = 1          ! The mean
     varname(im+(iv-1)*nm) = TRIM(ADJUSTL(vars(iv)%tag))
+    WRITE(str,*) im
+    vargroup(im+(iv-1)*nm)= 'Moment'//TRIM(ADJUSTL(str))
+    
     DO im = 2,nm    ! In case moments larger than 1 are used
       WRITE(varname(im+(iv-1)*nm),*) im
       varname(im+(iv-1)*nm)=TRIM(ADJUSTL(vars(iv)%tag))//'.'//TRIM(ADJUSTL(varname(im+(iv-1)*nm)))
+      WRITE(str,*) im
+      vargroup(im+(iv-1)*nm)= 'Moment'//TRIM(ADJUSTL(str))
     END DO
   END DO
 
-  CALL IO_WRITE_AVERAGES( fname, itime,rtime, nm*nv,ny, y, varname, avg )
+  CALL IO_WRITE_AVERAGES( fname, itime,rtime, nm*nv,ny, y, varname, vargroup, avg )
 
 #else
   ! -------------------------------------------------------------------
@@ -205,8 +210,7 @@ SUBROUTINE INTER_N_XZ(fname, itime,rtime, nx,ny,nz, np, parname, gate, y, inter)
 
   ! ###################################################################
 #ifdef USE_NETCDF
-  CALL IO_WRITE_AVERAGES( fname, itime,rtime, np,ny, y, parname, inter )
-
+  CALL IO_WRITE_AVERAGES( fname, itime,rtime, np,ny, y, parname, parname, inter )
 #else
   ! -------------------------------------------------------------------
   ! TkStat file

--- a/src/io/io_averages.f90
+++ b/src/io/io_averages.f90
@@ -6,7 +6,7 @@
 !# Write N profiles in netCDF format
 !#
 !########################################################################
-SUBROUTINE IO_WRITE_AVERAGES( fname, itime,rtime, nv,ny, y, varname, var )
+SUBROUTINE IO_WRITE_AVERAGES( fname, itime,rtime, nv,ny, y, varname, vargroup, var )
 
   USE DNS_CONSTANTS, ONLY : lfile
   USE NETCDF
@@ -17,7 +17,7 @@ SUBROUTINE IO_WRITE_AVERAGES( fname, itime,rtime, nv,ny, y, varname, var )
 #include "mpif.h"
 #endif
 
-  CHARACTER(LEN=*), INTENT(IN   ) :: fname, varname(nv)
+  CHARACTER(LEN=*), INTENT(IN   ) :: fname, varname(nv), vargroup(nv) 
   TINTEGER,         INTENT(IN   ) :: itime
   TREAL,            INTENT(IN   ) :: rtime
   TINTEGER,         INTENT(IN   ) :: ny,nv
@@ -49,6 +49,7 @@ SUBROUTINE IO_WRITE_AVERAGES( fname, itime,rtime, nv,ny, y, varname, var )
     CALL NC_CHECK( Nf90_DEF_VAR( fid, "it", NF90_INT,   (/ dtid /),itid) )
     DO iv = 1,nv
       CALL NC_CHECK( Nf90_DEF_VAR( fid, TRIM(ADJUSTL(varname(iv))), NF90_FLOAT, (/ dyid, dtid /), vid(iv)) )
+      CALL NC_CHECK( NF90_PUT_ATT( fid, vid(iv), 'group', vargroup(iv) ) )
     END DO
 
     CALL NC_CHECK( NF90_ENDDEF( fid ) )

--- a/src/mappings/avg_flow_xz.f90
+++ b/src/mappings/avg_flow_xz.f90
@@ -43,7 +43,7 @@ SUBROUTINE AVG_FLOW_XZ(q,s, dudx,dudy,dudz,dvdx,dvdy,dvdz,dwdx,dwdy,dwdz, mean2d
 
   ! -------------------------------------------------------------------
   TINTEGER, PARAMETER :: MAX_VARS_GROUPS = 20
-  TINTEGER j,k, bcs(2,2)
+  TINTEGER j,k, ivar, bcs(2,2)
   TREAL dummy
   TREAL c23, prefactor
 
@@ -53,7 +53,7 @@ SUBROUTINE AVG_FLOW_XZ(q,s, dudx,dudy,dudz,dvdx,dvdy,dvdz,dwdx,dwdy,dwdz, mean2d
   CHARACTER*250 line1, varname(MAX_VARS_GROUPS)
   CHARACTER*1300 line2
 
-  CHARACTER(LEN=32) varname2(MAX_AVG_TEMPORAL)
+  CHARACTER(LEN=32) varname2(MAX_AVG_TEMPORAL), vargroup2(MAX_AVG_TEMPORAL) 
 
   ! Pointers to existing allocated space
   TREAL, DIMENSION(:,:,:), POINTER :: u,v,w,p, e,rho, vis
@@ -1364,13 +1364,19 @@ SUBROUTINE AVG_FLOW_XZ(q,s, dudx,dudy,dudz,dvdx,dvdy,dvdz,dwdx,dwdy,dwdz, mean2d
   ! ###################################################################
 #ifdef USE_NETCDF
   line2 = ''
+  ivar=1 
   DO k = 1,ng
-    line2 = TRIM(ADJUSTL(line2))//' '//TRIM(ADJUSTL(varname(k)))
+     line2 = TRIM(ADJUSTL(line2))//' '//TRIM(ADJUSTL(varname(k)))
+     DO j=1,sg(k)
+        vargroup2(ivar)=groupname(k) 
+        ivar=ivar+1
+     ENDDO
   END DO
+
   CALL LIST_STRING( line2, nv, varname2 )
 
   WRITE(name,*) itime; name='avg'//TRIM(ADJUSTL(name))
-  CALL IO_WRITE_AVERAGES( name, itime,rtime, nv,jmax, g(2)%nodes, varname2, mean2d )
+  CALL IO_WRITE_AVERAGES( name, itime,rtime, nv,jmax, g(2)%nodes, varname2, vargroup2, mean2d )
 
 #else
 ! -----------------------------------------------------------------------

--- a/src/mappings/avg_scal_xz.f90
+++ b/src/mappings/avg_scal_xz.f90
@@ -40,7 +40,7 @@ SUBROUTINE AVG_SCAL_XZ(is, q,s, s_local, dsdx,dsdy,dsdz, tmp1,tmp2,tmp3, mean2d,
 
   ! -----------------------------------------------------------------------
   TINTEGER, PARAMETER :: MAX_VARS_GROUPS = 10
-  TINTEGER i,j,k, bcs(2,2)
+  TINTEGER i,j,k,ivar,bcs(2,2)
   TREAL diff, dummy, coefT, coefR, coefQ, c23
 
   TINTEGER ig(MAX_VARS_GROUPS), sg(MAX_VARS_GROUPS), ng, nmax
@@ -50,7 +50,7 @@ SUBROUTINE AVG_SCAL_XZ(is, q,s, s_local, dsdx,dsdy,dsdz, tmp1,tmp2,tmp3, mean2d,
   CHARACTER*850 line2
 
   TINTEGER nvar
-  CHARACTER(LEN=32) varname2(MAX_AVG_TEMPORAL)
+  CHARACTER(LEN=32) varname2(MAX_AVG_TEMPORAL), vargroup2(MAX_AVG_TEMPORAL) 
 
   ! Pointers to existing allocated space
   TREAL, DIMENSION(:,:,:), POINTER :: u,v,w,p, rho, vis
@@ -795,15 +795,20 @@ SUBROUTINE AVG_SCAL_XZ(is, q,s, s_local, dsdx,dsdy,dsdz, tmp1,tmp2,tmp3, mean2d,
   ! #######################################################################
 #ifdef USE_NETCDF
   line2 = ''
+  ivar=1
   DO k = 1,ng
-    line2 = TRIM(ADJUSTL(line2))//' '//TRIM(ADJUSTL(varname(k)))
+     line2 = TRIM(ADJUSTL(line2))//' '//TRIM(ADJUSTL(varname(k)))
+     DO j=1,sg(k)
+        vargroup2(ivar)=groupname(k)
+        ivar=ivar+1 
+     ENDDO
   END DO
   nvar = MAX_AVG_TEMPORAL
   CALL LIST_STRING( line2, nvar, varname2 )
 
   WRITE(line1,*) is; line1='avg'//TRIM(ADJUSTL(line1))//'s'
   WRITE(name,*) itime; name=TRIM(ADJUSTL(line1))//TRIM(ADJUSTL(name))
-  CALL IO_WRITE_AVERAGES( name, itime,rtime, nvar,jmax, g(2)%nodes, varname2, mean2d )
+  CALL IO_WRITE_AVERAGES( name, itime,rtime, nvar,jmax, g(2)%nodes, varname2, vargroup2, mean2d )
 
 #else
   ! -----------------------------------------------------------------------


### PR DESCRIPTION
Without any information, it can be quite confusing what is what, for instance Wy (vorticity) vs. W_y (derivative of W); the 'old' group name helps to clarify and is now maintained as an attribute of each variable. 

Note: Variable groups are not an option here as they would introduce another hierarchy to the file that complicates the access of variables a lot.  

[output / functionality checked for scalar and flow averages in serial and parallel on hawk] 