### PR TITLE
Move 2nd derivative calculation from opr_burgers to opr_partial

### DIFF
--- a/src/mappings/avg_scal_xz.f90
+++ b/src/mappings/avg_scal_xz.f90
@@ -29,12 +29,13 @@ SUBROUTINE AVG_SCAL_XZ(is, q,s, s_local, dsdx,dsdy,dsdz, tmp1,tmp2,tmp3, mean2d,
 
 #include "integers.h"
 
-  TINTEGER,                           INTENT(IN   ) :: is
-  TREAL, DIMENSION(imax,jmax,kmax,*), INTENT(IN   ) :: q, s
-  TREAL, DIMENSION(imax,jmax,kmax),   INTENT(IN   ) :: s_local
-  TREAL, DIMENSION(imax,jmax,kmax),   INTENT(INOUT) :: dsdx,dsdy,dsdz, tmp1,tmp2,tmp3, wrk3d
-  TREAL, DIMENSION(jmax,*),           INTENT(INOUT) :: mean2d, wrk1d
-  TREAL, DIMENSION(*),                INTENT(INOUT) :: wrk2d
+  TINTEGER,                                  INTENT(IN   ) :: is
+  TREAL, DIMENSION(imax,jmax,kmax,inb_flow), INTENT(IN   ) :: q
+  TREAL, DIMENSION(imax,jmax,kmax,inb_scal), INTENT(IN   ) :: s
+  TREAL, DIMENSION(imax,jmax,kmax),          INTENT(IN   ) :: s_local
+  TREAL, DIMENSION(imax,jmax,kmax),          INTENT(INOUT) :: dsdx,dsdy,dsdz, tmp1,tmp2,tmp3, wrk3d
+  TREAL, DIMENSION(jmax,*),                  INTENT(INOUT) :: mean2d, wrk1d
+  TREAL, DIMENSION(*),                       INTENT(INOUT) :: wrk2d
 
   TARGET q, s, tmp3
 

--- a/src/operators/opr_burgers.f90
+++ b/src/operators/opr_burgers.f90
@@ -40,84 +40,8 @@ SUBROUTINE OPR_BURGERS(is, nlines, bcs, g, s,u, result, wrk2d,wrk3d)
      CALL DNS_STOP(DNS_ERROR_UNDEVELOP)
   ENDIF
 
-! First derivative
-  CALL OPR_PARTIAL1(nlines, bcs, g, s,wrk3d, wrk2d)
-
-! -------------------------------------------------------------------
-! Periodic case
-! -------------------------------------------------------------------
-  IF ( g%periodic ) THEN
-     SELECT CASE( g%mode_fdm )
-
-     CASE( FDM_COM4_JACOBIAN )
-        CALL FDM_C2N4P_RHS(g%size,nlines, s, result)
-
-     CASE( FDM_COM6_JACOBIAN, FDM_COM6_DIRECT ) ! Direct = Jacobian because uniform grid
-       ! CALL FDM_C2N6P_RHS(g%size,nlines, s, result)
-       CALL FDM_C2N6HP_RHS(g%size,nlines, s, result)
-
-     CASE( FDM_COM8_JACOBIAN )                  ! Not yet implemented; default to 6. order
-        CALL FDM_C2N6P_RHS(g%size,nlines, s, result)
-
-     END SELECT
-
-     ip = is*5 ! LU decomposition containing the diffusivity
-     CALL TRIDPSS(g%size,nlines, g%lu2d(1,ip+1),g%lu2d(1,ip+2),g%lu2d(1,ip+3),g%lu2d(1,ip+4),g%lu2d(1,ip+5), result, wrk2d)
-! Trying speed-up by includind operation at the end of this routine inside tridpss, to reduce memory access
-!     CALL TRIDPSS_ADD(g%size,nlines, g%lu2d(1,ip+1),g%lu2d(1,ip+2),g%lu2d(1,ip+3),g%lu2d(1,ip+4),g%lu2d(1,ip+5), result, u,wrk3d, wrk2d)
-
-! -------------------------------------------------------------------
-! Nonperiodic case
-! -------------------------------------------------------------------
-  ELSE
-! ! Check whether we need 1. order derivative correction
-!      wrk2d(1:g%size) = C_0_R
-!      IF ( .NOT. g%uniform ) THEN
-!         IF ( g%mode_fdm .eq. FDM_COM4_JACOBIAN .OR. &
-!              g%mode_fdm .eq. FDM_COM6_JACOBIAN .OR. &
-!              g%mode_fdm .eq. FDM_COM8_JACOBIAN      ) THEN
-!            DO ip = 1,g%size
-!               wrk2d(ip) = g%jac(ip,2) /( g%jac(ip,1) *g%jac(ip,1) ) /reynolds
-! !           result(:,ip) = result(:,ip) - (wrk2d(ip) + u(:,ip)) *wrk3d(:,ip) ! inside tridss_add
-!            ENDDO
-
-!         ENDIF
-!      ENDIF
-
-     SELECT CASE( g%mode_fdm )
-
-     CASE( FDM_COM4_JACOBIAN )
-        IF ( g%uniform ) THEN
-           CALL FDM_C2N4_RHS  (g%size,nlines, bcs(1,2),bcs(2,2),        s,        result)
-        ELSE ! Not yet implemented
-        ENDIF
-     CASE( FDM_COM6_JACOBIAN )
-        IF ( g%uniform ) THEN
-          ! CALL FDM_C2N6_RHS  (g%size,nlines, bcs(1,2),bcs(2,2),        s,        result)
-          CALL FDM_C2N6H_RHS  (g%size,nlines, bcs(1,2),bcs(2,2),        s,        result)
-        ELSE
-          ! CALL FDM_C2N6NJ_RHS(g%size,nlines, bcs(1,2),bcs(2,2), g%jac, s, wrk3d, result)
-          CALL FDM_C2N6HNJ_RHS(g%size,nlines, bcs(1,2),bcs(2,2), g%jac, s, wrk3d, result)
-        ENDIF
-
-     CASE( FDM_COM8_JACOBIAN ) ! Not yet implemented; defaulting to 6. order
-        IF ( g%uniform ) THEN
-           CALL FDM_C2N6_RHS  (g%size,nlines, bcs(1,2),bcs(2,2),        s,        result)
-        ELSE
-           CALL FDM_C2N6NJ_RHS(g%size,nlines, bcs(1,2),bcs(2,2), g%jac, s, wrk3d, result)
-        ENDIF
-
-     CASE( FDM_COM6_DIRECT   )
-        CALL FDM_C2N6ND_RHS(g%size,nlines, g%lu2(1,4), s, result)
-
-     END SELECT
-
-     ip = is*3 ! LU decomposition containing the diffusivity
-     CALL TRIDSS(g%size,nlines, g%lu2d(1,ip+1),g%lu2d(1,ip+2),g%lu2d(1,ip+3), result)
-! Trying speed-up by includind operation at the end of this routine inside tridss, to reduce memory access
-!     CALL TRIDSS_ADD(g%size,nlines, g%lu2d(1,ip+1),g%lu2d(1,ip+2),g%lu2d(1,ip+3), result, u,wrk3d, wrk2d)
-
-  ENDIF
+  CALL OPR_PARTIAL2D(is,nlines,bcs,g,s,result,wrk2d,wrk3d)  ! wrk3d: 1st derivative
+                                                            ! result:2nd derivative including diffusivity   
 
 ! ###################################################################
 ! Operation; diffusivity included in 2.-order derivative

--- a/src/tools/dns/statistics.f90
+++ b/src/tools/dns/statistics.f90
@@ -52,6 +52,7 @@ CONTAINS
     USE DNS_TYPES, ONLY : pointers_dt
     USE DNS_GLOBAL,    ONLY : g
     USE DNS_GLOBAL,    ONLY : imax,jmax,kmax, isize_field, isize_txc_field, inb_scal_array
+    USE DNS_GLOBAL,    ONLY : inb_flow, inb_scal
     USE DNS_GLOBAL,    ONLY : buoyancy, imode_eqns, icalc_scal
     USE DNS_GLOBAL,    ONLY : itransport, froude
     USE DNS_GLOBAL,    ONLY : epbackground, pbackground, rbackground
@@ -67,14 +68,15 @@ CONTAINS
 
     IMPLICIT NONE
 
-    TREAL, DIMENSION(isize_field,    *), INTENT(IN)    :: q,s
-    TREAL, DIMENSION(isize_field,    *), INTENT(INOUT) :: hq ! auxiliary array
-    TREAL, DIMENSION(isize_txc_field,6), INTENT(INOUT) :: txc
-    TREAL, DIMENSION(*),                 INTENT(INOUT) :: wrk1d,wrk2d,wrk3d
+    TREAL, DIMENSION(isize_field,inb_flow), INTENT(IN)    :: q
+    TREAL, DIMENSION(isize_field,inb_scal), INTENT(IN)    :: s
+    TREAL, DIMENSION(isize_field,inb_flow), INTENT(INOUT) :: hq ! auxiliary array
+    TREAL, DIMENSION(isize_txc_field,6),    INTENT(INOUT) :: txc
+    TREAL, DIMENSION(*),                    INTENT(INOUT) :: wrk1d,wrk2d,wrk3d
 
-    TREAL, DIMENSION(isize_particle,*),  INTENT(IN)    :: l_q
-    TREAL, DIMENSION(isize_particle,*),  INTENT(INOUT) :: l_txc
-    TREAL, DIMENSION(*),                 INTENT(INOUT) :: l_comm
+    TREAL, DIMENSION(isize_particle,*),     INTENT(IN)    :: l_q
+    TREAL, DIMENSION(isize_particle,*),     INTENT(INOUT) :: l_txc
+    TREAL, DIMENSION(*),                    INTENT(INOUT) :: l_comm
 
     TARGET :: q,s, txc
 


### PR DESCRIPTION
1. [c2ad6ed] For the upcoming implementation of the IBM routines, it is quite useful to have the derivative calculations bundled in one place --> created subroutine OPR_PARTIAL2D (which includes the diffusivity); next step would be merging the two by creation of an underlying kernel routine for avoidance of duplicate code. 
2. [22cc5cd] For compliance with AMD compiler, we also have to specify inb_scal and inb_flow in the formerly assumed-size arrays for the scalar statistics and in module statistics. 




