### PR TITLE
fix git hash and git branch in dns.log

### DIFF
--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -1,20 +1,27 @@
 FILE(GLOB sourcefiles "*.f90")
 
-# retrieve the git hash from the current commit
+# retrieve current git branch and the git hash from the current commit
 find_package(Git)
 if(GIT_EXECUTABLE)
-  exec_program(git ${CMAKE_CURRENT_SOURCE_DIR} ARGS "describe --dirty" OUTPUT_VARIABLE GITHASH RETURN_VALUE GITRETURN)
+  exec_program(git ${CMAKE_CURRENT_SOURCE_DIR} ARGS "log -1 --format=%h" OUTPUT_VARIABLE GITHASH RETURN_VALUE GITRETURN)
   if(NOT GITRETURN MATCHES 0)
     set(GITHASH "not available")
   endif()
+  exec_program(git ${CMAKE_CURRENT_SOURCE_DIR} ARGS "rev-parse --abbrev-ref HEAD" OUTPUT_VARIABLE GITBRANCH RETURN_VALUE GITRETURN)
+  if(NOT GITRETURN MATCHES 0)
+    set(GITBRANCH "not available")
+  endif()
 else()
-  set(GITHASH "not available")
+  set(GITHASH   "not available")
+  set(GITBRANCH "not available")
 endif()
 
-message(STATUS "Git hash " ${GITHASH})
+message(STATUS "Git hash   " ${GITHASH})
+message(STATUS "Git branch " ${GITBRANCH})
 
 # send a precompiler statement replacing the git hash
 add_definitions(-DGITHASH="${GITHASH}")
+add_definitions(-DGITBRANCH="${GITBRANCH}")
 
 get_directory_property(defs COMPILE_DEFINITIONS)
 if ( "USE_MPI" IN_LIST defs )

--- a/src/modules/tlab_procs.f90
+++ b/src/modules/tlab_procs.f90
@@ -162,7 +162,10 @@ CONTAINS
     line='Starting on '//TRIM(ADJUSTL(clock(1)(1:8)))//' at '//TRIM(ADJUSTL(clock(2)))
     CALL TLAB_WRITE_ASCII(lfile,line)
 
-    line='Git-hash '//GITHASH
+    line='Git-hash   '//GITHASH
+    CALL TLAB_WRITE_ASCII(lfile,line)
+
+    line='Git-branch '//GITBRANCH
     CALL TLAB_WRITE_ASCII(lfile,line)
 
 #ifdef USE_MPI


### PR DESCRIPTION
Git hash command is fixed (command "git describe --dirty" ist not working).
Current name of git branch is added to dns.log file (for traceabillity reasons).