### PR TITLE
Runtime

### DIFF
--- a/src/modules/tlab_vars.f90
+++ b/src/modules/tlab_vars.f90
@@ -2,7 +2,7 @@
 
 module TLAB_VARS
     use TLAB_TYPES, only: grid_dt, filter_dt, subarray_dt, term_dt, profiles_dt
-    use TLAB_CONSTANTS, only: MAX_VARS, MAX_NSP, wp, wi
+    use TLAB_CONSTANTS, only: MAX_VARS, MAX_NSP, wp, wi, sp
     use TLAB_CONSTANTS, only: MAX_STATS_SPATIAL
     implicit none
     save
@@ -25,8 +25,8 @@ module TLAB_VARS
     integer :: iadvection, iviscous, idiffusion,  itransport ! formulation
     integer :: ifourier
     integer :: istagger, ivfilter       ! horizontal staggering of pressure
-    ! vertical   filtering  of pressure
-    real(wp) :: vfilter_param            ! vertical filter parameter
+                                        ! vertical   filtering  of pressure
+    real(wp) :: vfilter_param           ! vertical filter parameter
 
     integer :: imode_fdm                ! finite-difference method for spatial operators
 
@@ -37,6 +37,7 @@ module TLAB_VARS
 ! ###################################################################
     integer(wi) :: itime                    ! iteration number
     real(wp) :: rtime                       ! physical time
+    real(sp) :: wall_time                   ! walltime
 
 ! ###################################################################
 ! Arrays size

--- a/src/modules/tlab_vars.f90
+++ b/src/modules/tlab_vars.f90
@@ -25,8 +25,8 @@ module TLAB_VARS
     integer :: iadvection, iviscous, idiffusion,  itransport ! formulation
     integer :: ifourier
     integer :: istagger, ivfilter       ! horizontal staggering of pressure
-                                        ! vertical   filtering  of pressure
-    real(wp) :: vfilter_param           ! vertical filter parameter
+
+    real(wp) :: vfilter_param           ! vertical filter parameter of pressure
 
     integer :: imode_fdm                ! finite-difference method for spatial operators
 
@@ -37,7 +37,7 @@ module TLAB_VARS
 ! ###################################################################
     integer(wi) :: itime                    ! iteration number
     real(wp) :: rtime                       ! physical time
-    real(sp) :: wall_time                   ! walltime
+    real(sp) :: wall_time                   ! walltime (elapsed real time)
 
 ! ###################################################################
 ! Arrays size

--- a/src/tools/dns/dns_local.f90
+++ b/src/tools/dns/dns_local.f90
@@ -2,7 +2,7 @@
 #include "dns_const.h"
 
 module DNS_LOCAL
-    use TLAB_CONSTANTS, only: MAX_NSP, wp, wi
+    use TLAB_CONSTANTS, only: MAX_NSP, wp, wi, sp
 #ifdef USE_PSFFT
     use NB3DFFT, only: NB3DFFT_SCHEDLTYPE
 #endif
@@ -17,6 +17,7 @@ module DNS_LOCAL
     integer :: nitera_stats_spa ! Iteration step to accumulate statistics in spatial mode
     integer :: nitera_pln       ! Iteration step to save planes
     integer :: nitera_filter    ! Iteration step for domain filter, if any
+    real(wp):: nruntime_sec     ! Maximum runtime of the code in Seconds
 
     integer :: nitera_log           ! Iteration step for data logger with simulation information
     character(len=*), parameter :: ofile = 'dns.out'    ! data logger filename
@@ -86,9 +87,11 @@ contains
         use TLAB_VARS, only: imode_eqns, imode_ibm, istagger
         use TLAB_VARS, only: imax, jmax, kmax
         use TLAB_VARS, only: rbackground
+        use TLAB_VARS, only: wall_time
         use TLAB_ARRAYS
         use TLAB_PROCS
 #ifdef USE_MPI
+        use MPI
         use TLAB_MPI_VARS, only: ims_offset_i, ims_offset_k
 #endif
         use FI_VECTORCALCULUS
@@ -96,6 +99,7 @@ contains
         ! -------------------------------------------------------------------
         integer(wi) idummy(3)
         real(wp) dummy
+        real(sp),dimension(2):: tdummy
         character*128 line
         character*32 str
 
@@ -103,6 +107,12 @@ contains
         real(wp), dimension(:, :, :), pointer :: loc_max
 
         ! ###################################################################
+        ! Check wall time bounds - maximum runtime 
+#ifdef USE_MPI
+        wall_time = MPI_WTIME()
+#else
+        call ETIME(tdummy, wall_time)
+#endif       
         ! ###################################################################
         ! Compressible flow
         ! ###################################################################

--- a/src/tools/dns/dns_main.f90
+++ b/src/tools/dns/dns_main.f90
@@ -249,7 +249,8 @@ program DNS
         end if
 
         if (mod(itime - nitera_first, nitera_save) == 0 .or. &      ! Check-pointing: Save restart files
-            itime == nitera_last .or. int(logs_data(1)) /= 0) then  ! Secure that one restart file is saved
+            itime == nitera_last .or. int(logs_data(1)) /= 0 .or. & ! Secure that one restart file is saved 
+            wall_time > nruntime_sec) then                          ! If max runtime of the code is reached 
 
             if (icalc_flow == 1) then
                 write (fname, *) itime; fname = trim(adjustl(tag_flow))//trim(adjustl(fname))
@@ -285,6 +286,12 @@ program DNS
             call PLANES_SAVE()
         end if
 
+        if (wall_time > nruntime_sec) then 
+            write (str, *) wall_time
+            call TLAB_WRITE_ASCII(lfile, 'Maximum walltime of '//trim(adjustl(str))//' seconds is reached.')
+            exit
+        end if
+        
     end do
 
     ! ###################################################################

--- a/src/tools/dns/dns_read_local.f90
+++ b/src/tools/dns/dns_read_local.f90
@@ -102,6 +102,7 @@ subroutine DNS_READ_LOCAL(inifile)
     call TLAB_WRITE_ASCII(bakfile, '#IteraLog=<value>')
     call TLAB_WRITE_ASCII(bakfile, '#Saveplanes=<value>')
     call TLAB_WRITE_ASCII(bakfile, '#RunAvera=<yes/no>')
+    call TLAB_WRITE_ASCII(bakfile, '#Runtime=<seconds>')
 
     call SCANINIINT(bakfile, inifile, 'Iteration', 'Start', '0', nitera_first)
     call SCANINIINT(bakfile, inifile, 'Iteration', 'End', '0', nitera_last)
@@ -109,6 +110,7 @@ subroutine DNS_READ_LOCAL(inifile)
     call SCANINIINT(bakfile, inifile, 'Iteration', 'Statistics', '50', nitera_stats)
     call SCANINIINT(bakfile, inifile, 'Iteration', 'IteraLog', '10', nitera_log)
     call SCANINIINT(bakfile, inifile, 'Iteration', 'Saveplanes', '-1', nitera_pln)
+    call SCANINIREAL(bakfile,inifile, 'Iteration', 'Runtime', '10000000', nruntime_sec)
 
 ! Accumulate statistics in spatial mode
     call SCANINIINT(bakfile, inifile, 'Iteration', 'SaveStats', '-1', nitera_stats_spa)


### PR DESCRIPTION
Implementation of the option to set a fixed runtime of the code in seconds in dns.ini with:
"Runtime=<seconds>" in [Iterations]
After reaching this limit, restart fields are written to disk and the code is savely stopped.

This avoids losing computational resources when a certain maximum walltime is reached that does not coincide with the predefined iterationstep of writing restart fields. 

Works with/without MPI.