### PR TITLE
New data logger file 'dns.obs' for in situ measures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ examples/Case*/flow.*
 examples/Case*/scal.*
 examples/Case*/dns.out
 examples/Case*/dns.log
+examples/Case*/dns.obs
 examples/Case*/dns.ini.bak
 examples/Case*/rand.*
 examples/Case*/avg*

--- a/examples/Case41/dns.ini
+++ b/examples/Case41/dns.ini
@@ -23,6 +23,7 @@ End=10
 Restart=10
 Statistics=5
 IteraLog=1
+ObsLog=Ekman
 
 [Control]
 FlowLimit=no

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -45,7 +45,7 @@ PRJS=\
      # Case33 \
      # Case34 \
 
-FILES=avg* grid* flow* scal* dns.out dns.log dns.err dns.war dns.def dns.ini.bak tower* part* traj* residence* eps*
+FILES=avg* grid* flow* scal* dns.out dns.log dns.obs dns.err dns.war dns.def dns.ini.bak tower* part* traj* residence* eps*
 
 ##########################################################################
 #   Directives

--- a/scripts/templates/dns.nqs.sh.hlrs.hawk
+++ b/scripts/templates/dns.nqs.sh.hlrs.hawk
@@ -72,7 +72,7 @@ stat -t core* >/dev/null 2>&1 && ABORT="yes"
 if [ -f dns.ini ]; then
     cp dns.ini dns.ini-$TIMESTAMP
 fi
-LOGFILES="dns.ini.bak dns.log dns.out dns.les partinfos.txt mapping.txt"
+LOGFILES="dns.ini.bak dns.log dns.out dns.obs dns.les partinfos.txt mapping.txt"
 for FILE in $LOGFILES; do
     if [ -f $FILE ]; then
         mv $FILE $FILE-$TIMESTAMP

--- a/src/include/dns_const.h
+++ b/src/include/dns_const.h
@@ -182,4 +182,8 @@
 #define CS_BCS_NATURAL  3
 #define CS_BCS_FIXED_2  4
 
+! Obs log-file type
+#define OBS_TYPE_NONE  0
+#define OBS_TYPE_EKMAN 1
+
 #endif

--- a/src/tools/dns/dns_local.f90
+++ b/src/tools/dns/dns_local.f90
@@ -246,8 +246,8 @@ contains
 #define wbulk    obs_data(3)
 #define uy1      obs_data(4)
 #define wy1      obs_data(5)
-#define alpha_ny obs_data(6)
-#define alpha_1  obs_data(7)
+#define alpha_1  obs_data(6)
+#define alpha_ny obs_data(7)
         
         ip = 7
         

--- a/src/tools/dns/dns_main.f90
+++ b/src/tools/dns/dns_main.f90
@@ -467,12 +467,12 @@ contains
         select case (dns_obs_log)
         case (OBS_TYPE_EKMAN)
             write (line2, 200) (obs_data(ip), ip=2, 7)
-200         format(6(1x, E13.3))
+200         format(6(1x, E13.6))
             line1 = trim(line1)//trim(line2)
             if (scal_on) then
                 do is = 1, inb_scal
                     write (line2, 300) obs_data(7+is)
-300                 format(1x, E13.3)
+300                 format(1x, E13.6)
                     line1 = trim(line1)//trim(line2)
                 end do
             end if

--- a/src/tools/dns/dns_main.f90
+++ b/src/tools/dns/dns_main.f90
@@ -431,16 +431,16 @@ contains
 
         select case (dns_obs_log)
         case (OBS_TYPE_EKMAN)
-            line1 = line1(1:ip)//' '//' u_bulk';    ip = ip + 1 + 10
-            line1 = line1(1:ip)//' '//' w_bulk';    ip = ip + 1 + 10
-            line1 = line1(1:ip)//' '//' u_y(1)';    ip = ip + 1 + 10
-            line1 = line1(1:ip)//' '//' w_y(1)';    ip = ip + 1 + 10
-            line1 = line1(1:ip)//' '//' alpha(ny)'; ip = ip + 1 + 10
-            line1 = line1(1:ip)//' '//' alpha(1)';  ip = ip + 1 + 10
+            line1 = line1(1:ip)//' '//' u_bulk';    ip = ip + 1 + 13
+            line1 = line1(1:ip)//' '//' w_bulk';    ip = ip + 1 + 13
+            line1 = line1(1:ip)//' '//' u_y(1)';    ip = ip + 1 + 13
+            line1 = line1(1:ip)//' '//' w_y(1)';    ip = ip + 1 + 13
+            line1 = line1(1:ip)//' '//' alpha(1)';  ip = ip + 1 + 13
+            line1 = line1(1:ip)//' '//' alpha(ny)'; ip = ip + 1 + 13
             if (scal_on) then
                 do is = 1, inb_scal
                     write(str,*) is
-                    line1 = line1(1:ip)//' '//' s'//trim(adjustl(str))//'_y(1)';  ip = ip + 1 + 10
+                    line1 = line1(1:ip)//' '//' s'//trim(adjustl(str))//'_y(1)';  ip = ip + 1 + 13
                 end do
             end if
         end select
@@ -467,12 +467,12 @@ contains
         select case (dns_obs_log)
         case (OBS_TYPE_EKMAN)
             write (line2, 200) (obs_data(ip), ip=2, 7)
-200         format(6(1x, E10.3))
+200         format(6(1x, E13.3))
             line1 = trim(line1)//trim(line2)
             if (scal_on) then
                 do is = 1, inb_scal
                     write (line2, 300) obs_data(7+is)
-300                 format(1x, E10.3)
+300                 format(1x, E13.3)
                     line1 = trim(line1)//trim(line2)
                 end do
             end if

--- a/src/tools/dns/dns_read_local.f90
+++ b/src/tools/dns/dns_read_local.f90
@@ -102,6 +102,7 @@ subroutine DNS_READ_LOCAL(inifile)
     call TLAB_WRITE_ASCII(bakfile, '#Saveplanes=<value>')
     call TLAB_WRITE_ASCII(bakfile, '#RunAvera=<yes/no>')
     call TLAB_WRITE_ASCII(bakfile, '#Runtime=<seconds>')
+    call TLAB_WRITE_ASCII(bakfile, '#ObsLog=<None/Ekman>')
 
     call SCANINIINT(bakfile, inifile, 'Iteration', 'Start', '0', nitera_first)
     call SCANINIINT(bakfile, inifile, 'Iteration', 'End', '0', nitera_last)
@@ -117,6 +118,16 @@ subroutine DNS_READ_LOCAL(inifile)
 ! Domain Filter (Should we move it to Iteration?)
     call SCANINIINT(bakfile, inifile, 'Filter', 'Step', '0', nitera_filter)
     if (nitera_filter == 0) FilterDomain(:)%type = DNS_FILTER_NONE
+
+
+    call SCANINICHAR(bakfile, inifile, 'Iteration', 'ObsLog', 'none', sRes)
+    if (trim(adjustl(sRes)) == 'none') then; dns_obs_log = OBS_TYPE_NONE
+    else if (trim(adjustl(sRes)) == 'ekman') then; dns_obs_log = OBS_TYPE_EKMAN
+    else
+        call TLAB_WRITE_ASCII(efile, 'DNS_READ_LOCAL. ObsLog.')
+        call TLAB_STOP(DNS_ERROR_OPTION)
+    end if
+
 
 ! ###################################################################
 ! Control Limits


### PR DESCRIPTION
New data logging file in Tlab, called 'dns.obs' (in situ observation), to get on-the-fly measures of the simulation to ease the workflow. Right now, it is implemented only for Ekman flow, but can be easily extended for other setups. The computational overhead should be negligible.