### PR TITLE
Changes (IBM, IO of log-files, towers...)

### DIFF
--- a/config/juwels.cmake
+++ b/config/juwels.cmake
@@ -40,31 +40,34 @@ else( ${BUILD_TYPE} STREQUAL "SERIAL" )
   set(CMAKE_Fortran_COMPILER ifort)
 endif()
 
-#set(USER_Fortran_FLAGS          " -fpp ${USER_profile_FLAGS} -nbs -save-temps -simd-vec-threshold50 -unroll-aggressive ${USER_omp_FLAGS} " )
-set(USER_Fortran_FLAGS          " -fpp ${USER_profile_FLAGS} -O3 -nbs -save-temps -heap-arrays -simd -vec-threshold50 -unroll-aggressive ${USER_omp_FLAGS} " )
-set(USER_Fortran_FLAGS_RELEASE  " -march=skylake-avx512 -axcommon-avx512,SSE4.2 -qopt-prefetch -O3 -ipo" )
-#set(USER_Fortran_FLAGS_RELEASE  " -axCORE-AVX2 -qopt-prefetch -O3 -ipo" )
-set(USER_Fortran_FLAGS_DEBUG    " -g -traceback -debug all ")
+#set(USER_Fortran_FLAGS          " -fpp ${USER_profile_FLAGS} -nbs -save-temps -heap-arrays -vec-threshold50  ${USER_omp_FLAGS} " )
+#set(USER_Fortran_FLAGS_RELEASE  " -march=skylake-avx512 -axcommon-avx512,SSE4.2 -O3 -ipo" )
+#set(USER_Fortran_FLAGS_RELEASE  " -axCORE-AVX2 -O3 -ipo" )
+
+set(USER_Fortran_FLAGS         "-cpp -ffree-form -ffree-line-length-2048 -fno-automatic -fallow-argument-mismatch " )
+set(USER_Fortran_FLAGS_RELEASE "-march=skylake-avx512 -mtune=skylake-avx512 -O3 -ffinite-math-only -fprefetch-loop-arrays --param prefetch-latency=300 " )
+
+set(USER_Fortran_FLAGS_DEBUG    " -g -traceback -debug all " )
 
 if ( NOT CMAKE_BUILD_TYPE )
   set(CMAKE_BUILD_TYPE RELEASE)
 endif()
 
-add_definitions(-DUSE_FFTW -DUSE_BLAS -DUSE_MKL)
+add_definitions(-DUSE_FFTW -DUSE_BLAS -DUSE_MKL -DUSE_NETCDF)
 
 #set(FFTW_INCLUDE_DIR "/gpfs/software/juwels/stages/2018a/software/FFTW/3.3.7-ipsmpi-2018a/include/")
 #set(FFTW_LIB         "/gpfs/software/juwels/stages/2018a/software/FFTW/3.3.7-ipsmpi-2018a/lib/libfftw3.a")
+set(NC_INCLUDE_DIR   "/p/software/juwels/stages/2024/software/netCDF-Fortran/4.6.1-gpsmpi-2023a/include/ " )
 set(FFTW_LIB         "-lfftw3")
 #set(BLAS_LIB         "/gpfs/software/juwels/stages/2018a/software/imkl/2018.2.199-iimpi-2018a/mkl/lib/intel64/libmkl_blas95_ilp64.a")
 set(BLAS_LIB         "-lmkl_intel_lp64 -lmkl_sequential -lmkl_core")
+set(NCDF_LIB         "-lnetcdff")
 
-set(INCLUDE_DIRS ${FFTW_INCLUDE_DIR})
-set(LIBS         ${FFTW_LIB} ${BLAS_LIB})
+set(INCLUDE_DIRS ${FFTW_INCLUDE_DIR} ${NC_INCLUDE_DIR} )
+set(LIBS         ${NCDF_LIB} ${FFTW_LIB} ${BLAS_LIB})
 
-add_definitions(-DUSE_NETCDF)
-# set(NC_INCLUDE_DIR     "/usr/include")
 set(NC_LIB             "-L/usr/lib -lnetcdff -lnetcdf")
-# set(INCLUDE_DIRS ${INCLUDE_DIRS} ${NC_INCLUDE_DIR})
+set(INCLUDE_DIRS ${INCLUDE_DIRS} )
 set(LIBS ${LIBS} ${NC_LIB})
 
 if ( ${BUILD_TYPE} STREQUAL "NONBLOCKING" ) # use NB3DFFT library

--- a/scripts/bin/qsend
+++ b/scripts/bin/qsend
@@ -259,7 +259,7 @@ if [ $# -eq 0 ]; then
    echo "Is this correct (yes/no)"
    read answer
    if [ -z "$answer" ]; then
-      echo "You must answer yer or no"
+      echo "You must answer yes or no"
       exit 1
    fi
 

--- a/scripts/templates/dns.nqs.sh.hlrs.hawk
+++ b/scripts/templates/dns.nqs.sh.hlrs.hawk
@@ -22,6 +22,11 @@ TRASHDIR=$JOBDIR-transfered
 # Create Working Directories
 mkdir -p $LOCALDIR
 
+# Avoid catching lustre problems 
+# (write logs [dns.log, dns.out, dns.obs] to home, afterwards copy back)
+export DNS_LOGGER_PATH=$HOME/logs/logs-$TIMESTAMP
+mkdir -p $DNS_LOGGER_PATH
+
 #####################################################################
 # USE CUSTOM LFS STRIPING TO OVERRIDE THE UNFORTUNATE DEFAULT VALUES  
 #    --stripe_count -1: use all available OSF's 
@@ -38,6 +43,9 @@ dns.pre $LOCALDIR $STEP
 touch *
 
 module load aocc/2.1.0 mpt/2.23 fftw/3.3.8 amd-libm
+
+# Write list of used nodes
+cat $PBS_NODEFILE > nodefile.txt
 
 # Run Simulation
 case $RUNMODE in
@@ -68,16 +76,26 @@ fi
 
 stat -t core* >/dev/null 2>&1 && ABORT="yes"
 
-#clean
+# Clean
 if [ -f dns.ini ]; then
     cp dns.ini dns.ini-$TIMESTAMP
 fi
-LOGFILES="dns.ini.bak dns.log dns.out dns.obs dns.les partinfos.txt mapping.txt"
+LOGFILES="dns.ini.bak dns.log dns.out dns.obs dns.les partinfos.txt mapping.txt nodefile.txt"
 for FILE in $LOGFILES; do
     if [ -f $FILE ]; then
         mv $FILE $FILE-$TIMESTAMP
     fi
 done
+
+# Copy log-files from home to localdir
+cd $DNS_LOGGER_PATH
+for FILE in $LOGFILES; do
+    if [ -f $FILE ]; then
+        mv $FILE $FILE-$TIMESTAMP
+        cp $FILE-$TIMESTAMP $LOCALDIR
+    fi
+done
+cd $LOCALDIR
 
 # Organize statistics
 STATSDIR=stats-$TIMESTAMP

--- a/src/ibm/ibm_initialize.f90
+++ b/src/ibm/ibm_initialize.f90
@@ -1,4 +1,5 @@
 #include "dns_error.h"
+#include "dns_const.h"
 !########################################################################
 !# HISTORY / AUTHORS
 !#
@@ -143,7 +144,7 @@ end subroutine IBM_INITIALIZE_GEOMETRY
 subroutine IBM_IO_READ(wrk3d, flag_epsp)
 
   use IBM_VARS
-  use TLAB_VARS,      only : imax,jmax,kmax, isize_field
+  use TLAB_VARS,      only : imax,jmax,kmax, isize_field, imode_files
   use TLAB_CONSTANTS, only : wp, wi
   use IO_FIELDS
   
@@ -156,19 +157,29 @@ subroutine IBM_IO_READ(wrk3d, flag_epsp)
   
     ! ================================================================== !
   wrk3d(:) = 0.0_wp
-  select case( ibm_io )
-    case ( IBM_IO_REAL )
-      if (flag_epsp) then
-        name = epsp_name_real
-        call IO_READ_FIELDS(name, IO_FLOW, imax,jmax,kmax, 1, 0, epsp)
-      else
-        name = eps_name_real
-        call IO_READ_FIELDS(name, IO_FLOW, imax,jmax,kmax, 1, 0, eps)
-      end if
-    case ( IBM_IO_INT  )
-      call IBM_IO_READ_INT_GEOMETRY(wrk3d, flag_epsp)
-    case ( IBM_IO_BIT  )
-      call IBM_IO_READ_BIT_GEOMETRY(wrk3d, flag_epsp)
+  select case( imode_files )
+  case ( IO_NOFILE ) ! no IO
+    if (flag_epsp) then
+      epsp = 0.0_wp
+    else
+      eps  = 0.0_wp
+    end if
+  case ( IO_NETCDF ) ! not implemented
+  case default       ! mpiio - file with header
+    select case( ibm_io )
+      case ( IBM_IO_REAL )
+        if (flag_epsp) then
+          name = epsp_name_real
+          call IO_READ_FIELDS(name, IO_FLOW, imax,jmax,kmax, 1, 0, epsp)
+        else
+          name = eps_name_real
+          call IO_READ_FIELDS(name, IO_FLOW, imax,jmax,kmax, 1, 0, eps)
+        end if
+      case ( IBM_IO_INT  )
+        call IBM_IO_READ_INT_GEOMETRY(wrk3d, flag_epsp)
+      case ( IBM_IO_BIT  )
+        call IBM_IO_READ_BIT_GEOMETRY(wrk3d, flag_epsp)
+    end select 
   end select 
   
   return
@@ -179,7 +190,7 @@ end subroutine IBM_IO_READ
 subroutine IBM_IO_WRITE(wrk3d, flag_epsp)
 
   use IBM_VARS
-  use TLAB_VARS,      only : imax,jmax,kmax, isize_field
+  use TLAB_VARS,      only : imax,jmax,kmax, isize_field, imode_files
   use TLAB_CONSTANTS, only : wp, wi
   use IO_FIELDS
   
@@ -192,19 +203,24 @@ subroutine IBM_IO_WRITE(wrk3d, flag_epsp)
   
     ! ================================================================== !
   wrk3d(:) = 0.0_wp
-  select case( ibm_io )
-    case ( IBM_IO_REAL )
-      if (flag_epsp) then
-        name = epsp_name_real
-        call IO_WRITE_FIELDS(name, IO_FLOW, imax,jmax,kmax, 1, epsp)
-      else
-        name = eps_name_real
-        call IO_WRITE_FIELDS(name, IO_FLOW, imax,jmax,kmax, 1, eps)
-      end if
-    case ( IBM_IO_INT  )
-      call IBM_IO_WRITE_INT_GEOMETRY(wrk3d, flag_epsp)
-    case ( IBM_IO_BIT  )
-      call IBM_IO_WRITE_BIT_GEOMETRY(wrk3d, flag_epsp)
+  select case( imode_files )
+  case ( IO_NOFILE ) ! no IO
+  case ( IO_NETCDF ) ! not implemented
+  case default       ! mpiio - file with header
+    select case( ibm_io )
+      case ( IBM_IO_REAL )
+        if (flag_epsp) then
+          name = epsp_name_real
+          call IO_WRITE_FIELDS(name, IO_FLOW, imax,jmax,kmax, 1, epsp)
+        else
+          name = eps_name_real
+          call IO_WRITE_FIELDS(name, IO_FLOW, imax,jmax,kmax, 1, eps)
+        end if
+      case ( IBM_IO_INT  )
+        call IBM_IO_WRITE_INT_GEOMETRY(wrk3d, flag_epsp)
+      case ( IBM_IO_BIT  )
+        call IBM_IO_WRITE_BIT_GEOMETRY(wrk3d, flag_epsp)
+    end select 
   end select 
   
   return

--- a/src/ibm/ibm_read.f90
+++ b/src/ibm/ibm_read.f90
@@ -25,7 +25,8 @@
 
 subroutine IBM_READ_INI(inifile)
 
-  use TLAB_CONSTANTS, only : efile, lfile
+  use TLAB_CONSTANTS, only : efile
+  USE TLAB_VARS,      only : lfile 
   use TLAB_PROCS,     only : TLAB_STOP, TLAB_WRITE_ASCII
   use IBM_VARS
   

--- a/src/io/io_averages.f90
+++ b/src/io/io_averages.f90
@@ -7,7 +7,8 @@
 !#
 !########################################################################
 subroutine IO_WRITE_AVERAGES(fname, itime, rtime, ny, nv, ng, y, varnames, groupnames, avg)
-    use TLAB_CONSTANTS, only: lfile, efile, wp, wi
+    use TLAB_CONSTANTS, only: efile, wp, wi
+    use TLAB_VARS, only: lfile
     use TLAB_PROCS
 #ifdef USE_MPI
     use MPI

--- a/src/io/io_fields.f90
+++ b/src/io/io_fields.f90
@@ -18,7 +18,8 @@
 !########################################################################
 
 module IO_FIELDS
-    use TLAB_CONSTANTS, only: lfile, wfile, efile, wp, wi, sp, dp, sizeofint, sizeofreal
+    use TLAB_CONSTANTS, only: wfile, efile, wp, wi, sp, dp, sizeofint, sizeofreal
+    use TLAB_VARS, only: lfile
     use TLAB_PROCS, only: TLAB_STOP, TLAB_WRITE_ASCII
     use TLAB_ARRAYS, only: wrk3d
 #ifdef USE_MPI

--- a/src/io/io_read_global.f90
+++ b/src/io/io_read_global.f90
@@ -12,7 +12,7 @@
 !########################################################################
 subroutine IO_READ_GLOBAL(inifile)
 
-    use TLAB_CONSTANTS, only: wp, wi, lfile, efile, wfile, MajorVersion, MinorVersion
+    use TLAB_CONSTANTS, only: wp, wi, efile, wfile, MajorVersion, MinorVersion
     use TLAB_VARS
     use TLAB_PROCS
     use THERMO_VARS
@@ -60,7 +60,8 @@ subroutine IO_READ_GLOBAL(inifile)
 ! ###################################################################
     call TLAB_WRITE_ASCII(bakfile, '#')
     call TLAB_WRITE_ASCII(bakfile, '#[Main]')
-    call TLAB_WRITE_ASCII(bakfile, '#FileFormat=<mpiio/RawSplit/NetCDF>')
+    call TLAB_WRITE_ASCII(bakfile, '#FileFormat=<mpiio/NetCDF/None>')
+    call TLAB_WRITE_ASCII(bakfile, '#FileType=<Double/Single>')
     call TLAB_WRITE_ASCII(bakfile, '#VerbosityLevel=<0/1/2>')
     call TLAB_WRITE_ASCII(bakfile, '#Type=<temporal/spatial>')
     call TLAB_WRITE_ASCII(bakfile, '#CalculateFlow=<yes/no>')
@@ -393,7 +394,7 @@ subroutine IO_READ_GLOBAL(inifile)
         if (abs(buoyancy%vector(3)) > 0.0_wp) then; buoyancy%active(3) = .true.; call TLAB_WRITE_ASCII(lfile, 'Body force along Oz.'); end if
 
         if (froude > 0.0_wp) then
-            buoyancy%vector(:) = buoyancy%vector(:)/froude ! adding the froude number into de vector g
+            buoyancy%vector(:) = buoyancy%vector(:)/froude ! adding the froude number into the vector g
         else
             call TLAB_WRITE_ASCII(efile, C_FILE_LOC//'. Froude number must be nonzero if buoyancy is retained.')
             call TLAB_STOP(DNS_ERROR_OPTION)

--- a/src/io/io_spatial.f90
+++ b/src/io/io_spatial.f90
@@ -11,7 +11,8 @@
 !#
 !########################################################################
 subroutine IO_WRITE_AVG_SPATIAL(name, mean_flow, mean_scal)
-    use TLAB_CONSTANTS, only: lfile, wp, wi
+    use TLAB_CONSTANTS, only: wp, wi
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: istattimeorg, rstattimeorg, nstatavg_points, nstatavg, statavg
     use TLAB_VARS, only: itime, rtime, jmax, inb_scal
 
@@ -123,7 +124,8 @@ end subroutine WRT_STHD
 #define LOC_STATUS 'old'
 
 subroutine IO_READ_AVG_SPATIAL(name, mean_flow, mean_scal)
-    use TLAB_CONSTANTS, only: lfile, wp, wi
+    use TLAB_CONSTANTS, only: wp, wi
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: istattimeorg, rstattimeorg, nstatavg_points, nstatavg, statavg
     use TLAB_VARS, only: itime, rtime, jmax, inb_scal
     use TLAB_PROCS

--- a/src/mappings/avg_flow_xz.f90
+++ b/src/mappings/avg_flow_xz.f90
@@ -16,7 +16,7 @@
 
 subroutine AVG_FLOW_XZ(q, s, dudx, dudy, dudz, dvdx, dvdy, dvdz, dwdx, dwdy, dwdz, mean2d)
     use TLAB_CONSTANTS, only: MAX_AVG_TEMPORAL
-    use TLAB_CONSTANTS, only: efile, lfile, wp, wi
+    use TLAB_CONSTANTS, only: efile, wp, wi
     use TLAB_VARS
     use TLAB_PROCS
     use TLAB_ARRAYS, only: wrk1d

--- a/src/mappings/avg_scal_xz.f90
+++ b/src/mappings/avg_scal_xz.f90
@@ -16,7 +16,7 @@
 
 subroutine AVG_SCAL_XZ(is, q, s, s_local, dsdx, dsdy, dsdz, tmp1, tmp2, tmp3, mean2d)
     use TLAB_CONSTANTS, only: MAX_AVG_TEMPORAL
-    use TLAB_CONSTANTS, only: efile, lfile, wp, wi
+    use TLAB_CONSTANTS, only: efile, wp, wi
     use TLAB_VARS
     use TLAB_ARRAYS, only: wrk1d
     use TLAB_POINTERS_3D, only: p_wrk3d

--- a/src/mappings/avg_xz.f90
+++ b/src/mappings/avg_xz.f90
@@ -8,7 +8,8 @@
 !#
 !########################################################################
 subroutine AVG_N_XZ(fname, itime, rtime, nx, ny, nz, nv, nm, vars, igate, gate, y, avg)
-    use TLAB_CONSTANTS, only: efile, lfile, wp, wi
+    use TLAB_CONSTANTS, only: efile, wp, wi
+    use TLAB_VARS,  only: lfile
     use TLAB_TYPES, only: pointers_dt
     use TLAB_PROCS
     use AVGS, only: AVG1V2d, AVG1V2D1G
@@ -107,7 +108,8 @@ end subroutine RAW_TO_CENTRAL
 !#
 !########################################################################
 subroutine INTER_N_XZ(fname, itime, rtime, nx, ny, nz, np, parname, gate, y, inter)
-    use TLAB_CONSTANTS, only: efile, lfile, wp, wi
+    use TLAB_CONSTANTS, only: efile, wp, wi
+    use TLAB_VARS, only: lfile
     use TLAB_PROCS
     use AVGS, only: INTER1V2D
 

--- a/src/mappings/cavg.f90
+++ b/src/mappings/cavg.f90
@@ -5,7 +5,8 @@
 !#
 !########################################################################
 subroutine CAVG1V_N(fname, time, nx, ny, nz, nv, nbins, ibc, umin, umax, u, igate, gate, a, y, avg)
-    use TLAB_CONSTANTS, only: lfile, wp, wi
+    use TLAB_CONSTANTS, only: wp, wi
+    use TLAB_VARS, only: lfile
     use TLAB_TYPES, only: pointers_dt
     use TLAB_ARRAYS, only: wrk1d
     use TLAB_PROCS
@@ -91,7 +92,8 @@ end subroutine CAVG1V_N
 !########################################################################
 !########################################################################
 subroutine CAVG2V(fname, time, nx, ny, nz, nbins, u, v, a, y, avg)
-    use TLAB_CONSTANTS, only: lfile, wp, wi
+    use TLAB_CONSTANTS, only: wp, wi
+    use TLAB_VARS, only: lfile
     use TLAB_PROCS
     use TLAB_ARRAYS, only: wrk2d
     use PDFS

--- a/src/mappings/fi_background.f90
+++ b/src/mappings/fi_background.f90
@@ -5,7 +5,8 @@
 !# Initialize data of reference thermodynamic profiles
 !########################################################################
 subroutine FI_BACKGROUND_INITIALIZE()
-    use TLAB_CONSTANTS, only: lfile, wp, wi
+    use TLAB_CONSTANTS, only: wp, wi
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: inb_scal, inb_scal_array, imax, jmax, kmax, imode_eqns
     use TLAB_VARS, only: g
     use TLAB_VARS, only: qbg, pbg, rbg, tbg, hbg, sbg

--- a/src/mappings/fi_sources.f90
+++ b/src/mappings/fi_sources.f90
@@ -272,17 +272,23 @@ contains
 !# when it is a function of a scalar
 !########################################################################
     subroutine FI_BUOYANCY(buoyancy, nx, ny, nz, s, b, ref)
+        use TLAB_VARS,   only: g
+        use TLAB_ARRAYS, only: wrk1d
+        use AVGS,        only: AVG1V2D_V
+
         type(term_dt), intent(in) :: buoyancy
         integer(wi), intent(in) :: nx, ny, nz
         real(wp), intent(in) :: s(nx, ny, nz, inb_scal_array)
         real(wp), intent(out) :: b(nx, ny, nz)
-        real(wp), intent(in) :: ref(ny)         ! reference profile
+        real(wp), intent(inout) :: ref(ny)         ! reference profile
 
         ! -----------------------------------------------------------------------
         integer(wi) j, k
         real(wp) c0_loc, c1_loc, c2_loc, c3_loc, dummy
 
         ! #######################################################################
+        CALL AVG1V2D_V(nx,ny,nz,1,s(:,:,:,1),ref(:),b) ! (mis)using b as work space
+
         select case (buoyancy%type)
 
         case (EQNS_BOD_HOMOGENEOUS)
@@ -352,6 +358,9 @@ contains
                 end do
             end do
 
+         case DEFAULT
+            b=0.0_wp
+            
         end select
 
         return

--- a/src/mappings/fi_sources.f90
+++ b/src/mappings/fi_sources.f90
@@ -272,23 +272,17 @@ contains
 !# when it is a function of a scalar
 !########################################################################
     subroutine FI_BUOYANCY(buoyancy, nx, ny, nz, s, b, ref)
-        use TLAB_VARS,   only: g
-        use TLAB_ARRAYS, only: wrk1d
-        use AVGS,        only: AVG1V2D_V
-
         type(term_dt), intent(in) :: buoyancy
         integer(wi), intent(in) :: nx, ny, nz
         real(wp), intent(in) :: s(nx, ny, nz, inb_scal_array)
         real(wp), intent(out) :: b(nx, ny, nz)
-        real(wp), intent(inout) :: ref(ny)         ! reference profile
+        real(wp), intent(in) :: ref(ny)         ! reference profile
 
         ! -----------------------------------------------------------------------
         integer(wi) j, k
         real(wp) c0_loc, c1_loc, c2_loc, c3_loc, dummy
 
         ! #######################################################################
-        CALL AVG1V2D_V(nx,ny,nz,1,s(:,:,:,1),ref(:),b) ! (mis)using b as work space
-
         select case (buoyancy%type)
 
         case (EQNS_BOD_HOMOGENEOUS)
@@ -358,9 +352,6 @@ contains
                 end do
             end do
 
-         case DEFAULT
-            b=0.0_wp
-            
         end select
 
         return

--- a/src/mappings/pdf.f90
+++ b/src/mappings/pdf.f90
@@ -12,7 +12,8 @@
 !#
 !########################################################################
 subroutine PDF1V_N(fname, time, nx, ny, nz, nv, nbins, ibc, umin, umax, u, igate, gate, y, pdf)
-    use TLAB_CONSTANTS, only: lfile, wp, wi
+    use TLAB_CONSTANTS, only: wp, wi
+    use TLAB_VARS, only: lfile
     use TLAB_TYPES, only: pointers_dt
     use TLAB_ARRAYS, only: wrk1d
     use TLAB_PROCS
@@ -121,7 +122,8 @@ end subroutine PDF1V_N
 !########################################################################
 !########################################################################
 subroutine PDF2V(fname, time, nx, ny, nz, nbins, u, v, y, pdf)
-    use TLAB_CONSTANTS, only: lfile,  wp, wi
+    use TLAB_CONSTANTS, only: wp, wi
+    use TLAB_VARS,   only: lfile
     use TLAB_ARRAYS, only: wrk2d
     use TLAB_PROCS
     use PDFS

--- a/src/modules/tlab_constants.f90
+++ b/src/modules/tlab_constants.f90
@@ -13,13 +13,16 @@ module TLAB_CONSTANTS
     integer, parameter :: MAX_NSP = 10  ! Species in the mixture
     integer, parameter :: MAX_AVG_TEMPORAL = 235
     integer, parameter :: MAX_STATS_SPATIAL = 100 ! Running statistics
-
+    integer, parameter :: MAX_PATH_LENGTH = 128
+    
     character(len=*), parameter :: gfile = 'grid'
+
     character(len=*), parameter :: ifile = 'dns.ini'
-    character(len=*), parameter :: lfile = 'dns.log'
     character(len=*), parameter :: efile = 'dns.err'
     character(len=*), parameter :: wfile = 'dns.war'
     character(len=*), parameter :: tfile = 'dns.trc'
+
+    character(len=*), parameter :: lfile_base = 'dns.log'
 
     character(len=*), parameter :: tag_flow = 'flow.'
     character(len=*), parameter :: tag_scal = 'scal.'

--- a/src/modules/tlab_mpi_procs.f90
+++ b/src/modules/tlab_mpi_procs.f90
@@ -4,8 +4,8 @@
 
 module TLAB_MPI_PROCS
     use MPI
-    use TLAB_CONSTANTS, only: lfile, efile, wp, wi
-    use TLAB_VARS, only: imax, jmax, kmax, isize_txc_dimx, isize_txc_dimz
+    use TLAB_CONSTANTS, only: efile, wp, wi
+    use TLAB_VARS, only: imax, jmax, kmax, isize_txc_dimx, isize_txc_dimz, lfile
     use TLAB_VARS, only: fourier_on
     use TLAB_PROCS, only: TLAB_WRITE_ASCII, TLAB_STOP
     use TLAB_MPI_VARS

--- a/src/modules/tlab_vars.f90
+++ b/src/modules/tlab_vars.f90
@@ -1,7 +1,7 @@
 module TLAB_VARS
     use TLAB_TYPES, only: grid_dt, filter_dt, term_dt, profiles_dt
     use TLAB_CONSTANTS, only: MAX_VARS, MAX_NSP, wp, wi, sp
-    use TLAB_CONSTANTS, only: MAX_STATS_SPATIAL
+    use TLAB_CONSTANTS, only: MAX_STATS_SPATIAL, MAX_PATH_LENGTH
     implicit none
     save
 
@@ -11,6 +11,12 @@ module TLAB_VARS
     integer :: dns_omp_numThreads
     integer :: dns_omp_error
 
+! ###################################################################
+! FILE NAMES
+! ###################################################################
+    character(len=MAX_PATH_LENGTH) :: logger_path
+    character(len=MAX_PATH_LENGTH) :: lfile
+    
 ! ###################################################################
 ! General options
 ! ###################################################################

--- a/src/operators/opr_check.f90
+++ b/src/operators/opr_check.f90
@@ -4,7 +4,8 @@
 #endif
 
 subroutine OPR_CHECK()
-    use TLAB_CONSTANTS, only: lfile, wp, wi
+    use TLAB_CONSTANTS, only: wp, wi
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: imax, jmax, kmax, isize_field, inb_flow_array, inb_txc
     use TLAB_VARS, only: g
     use TLAB_VARS, only: fourier_on

--- a/src/operators/opr_interpolate.f90
+++ b/src/operators/opr_interpolate.f90
@@ -15,7 +15,7 @@ module OPR_INTERPOLATORS
     use TLAB_VARS, only: isize_txc_field
     use TLAB_PROCS
 #ifdef USE_MPI
-    use TLAB_CONSTANTS, only: lfile
+    use TLAB_VARS, only: lfile
     use TLAB_MPI_VARS, only: ims_npro_i, ims_npro_k
     use TLAB_MPI_VARS, only: ims_size_i, ims_ds_i, ims_dr_i, ims_ts_i, ims_tr_i
     use TLAB_MPI_VARS, only: ims_size_k, ims_ds_k, ims_dr_k, ims_ts_k, ims_tr_k

--- a/src/particles/io_particle.f90
+++ b/src/particles/io_particle.f90
@@ -12,7 +12,8 @@
 #define LOC_STATUS 'old'
 
 subroutine IO_READ_PARTICLE(fname, l_g, l_q)
-    use TLAB_CONSTANTS, only: wp, wi, longi, lfile, efile, sizeofint, sizeofreal, sizeoflongint
+    use TLAB_CONSTANTS, only: wp, wi, longi, efile, sizeofint, sizeofreal, sizeoflongint
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: g
     use TLAB_PROCS
     use PARTICLE_VARS, only: isize_part, inb_part_array, isize_part_total
@@ -153,8 +154,9 @@ end subroutine IO_READ_PARTICLE
 
 subroutine IO_WRITE_PARTICLE(fname, l_g, l_q)
 
-    use TLAB_CONSTANTS, only: wp, wi, longi, lfile, sizeofint, sizeoflongint
-    use PARTICLE_VARS, only: isize_part, inb_part_array
+    use TLAB_CONSTANTS, only: wp, wi, longi, sizeofint, sizeoflongint
+    use TLAB_VARS,      only: lfile
+    use PARTICLE_VARS,  only: isize_part, inb_part_array
     use TLAB_PROCS
     use PARTICLE_TYPES, only: particle_dt
 #ifdef USE_MPI

--- a/src/particles/particle_interpolate.f90
+++ b/src/particles/particle_interpolate.f90
@@ -1,7 +1,8 @@
 #include "dns_error.h"
 
 module PARTICLE_INTERPOLATE
-    use TLAB_CONSTANTS, only: wp, wi, efile, lfile
+    use TLAB_CONSTANTS, only: wp, wi, efile
+    use TLAB_VARS, only: lfile
     use TLAB_TYPES, only: pointers_dt, pointers3d_dt
     use TLAB_VARS, only: imax, jmax, kmax
     use TLAB_VARS, only: g

--- a/src/particles/particle_read_global.f90
+++ b/src/particles/particle_read_global.f90
@@ -2,7 +2,8 @@
 #include "dns_const.h"
 
 subroutine PARTICLE_READ_GLOBAL(inifile)
-    use TLAB_CONSTANTS, only: wp, wi, longi, efile, lfile
+    use TLAB_CONSTANTS, only: wp, wi, longi, efile
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: inb_flow_array, inb_scal_array
     use PARTICLE_VARS
     use TLAB_PROCS

--- a/src/thermodynamics/thermo_initialize.f90
+++ b/src/thermodynamics/thermo_initialize.f90
@@ -25,7 +25,8 @@
 !#
 !########################################################################
 subroutine THERMO_INITIALIZE()
-    use TLAB_CONSTANTS, only: efile, lfile, wi, wp
+    use TLAB_CONSTANTS, only: efile, wi, wp
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: inb_scal, inb_scal_array, imode_eqns, mach
     use TLAB_VARS, only: damkohler, transport, radiation
     use TLAB_PROCS

--- a/src/tools/dns/boundary_bcs.f90
+++ b/src/tools/dns/boundary_bcs.f90
@@ -122,10 +122,11 @@ contains
 ! ###################################################################
     subroutine BOUNDARY_BCS_INITIALIZE()
         use TLAB_TYPES, only: profiles_dt
-        use TLAB_CONSTANTS, only: tag_flow, tag_scal, lfile, efile
+        use TLAB_CONSTANTS, only: tag_flow, tag_scal, efile
 #ifdef TRACE_ON
         use TLAB_CONSTANTS, only: tfile
 #endif
+        use TLAB_VARS, only: lfile
         use TLAB_VARS, only: imode_eqns
         use TLAB_VARS, only: imax, jmax, kmax, inb_flow, inb_scal, inb_flow_array, inb_scal_array
         use TLAB_VARS, only: g
@@ -513,7 +514,7 @@ contains
         use TLAB_CONSTANTS, only: tfile
         use TLAB_PROCS, only: TLAB_WRITE_ASCII
 #endif
-        use TLAB_CONSTANTS, only: lfile
+        use TLAB_VARS, only: lfile
         use TLAB_VARS, only: imax, jmax, kmax, g
         use TLAB_VARS, only: isize_field
         use TLAB_VARS, only: visc, schmidt

--- a/src/tools/dns/boundary_buffer.f90
+++ b/src/tools/dns/boundary_buffer.f90
@@ -18,10 +18,11 @@ module BOUNDARY_BUFFER
 
     use TLAB_TYPES, only: filter_dt
 
-    use TLAB_CONSTANTS, only: tag_flow, tag_scal, wfile, lfile, efile, MAX_VARS, wp, wi
+    use TLAB_CONSTANTS, only: tag_flow, tag_scal, wfile, efile, MAX_VARS, wp, wi
 #ifdef TRACE_ON
     use TLAB_CONSTANTS, only: tfile
 #endif
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: imode_eqns, imode_sim
     use TLAB_VARS, only: imax, jmax, kmax, inb_flow, inb_scal, isize_field
     use TLAB_VARS, only: g

--- a/src/tools/dns/boundary_inflow.f90
+++ b/src/tools/dns/boundary_inflow.f90
@@ -9,10 +9,11 @@
 !########################################################################
 module BOUNDARY_INFLOW
     use TLAB_TYPES, only: filter_dt, grid_dt, discrete_dt
-    use TLAB_CONSTANTS, only: efile, lfile, wp, wi
+    use TLAB_CONSTANTS, only: efile, wp, wi
 #ifdef TRACE_ON
     use TLAB_CONSTANTS, only: tfile
 #endif
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: imax, jmax, kmax, inb_flow, inb_scal, inb_flow_array, inb_scal_array, flow_on, scal_on
     use TLAB_VARS, only: imode_eqns, itransport
     use TLAB_VARS, only: g, qbg

--- a/src/tools/dns/dns_filter.f90
+++ b/src/tools/dns/dns_filter.f90
@@ -4,7 +4,7 @@
 !########################################################################
 subroutine DNS_FILTER()
 
-    use TLAB_CONSTANTS, only: lfile
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: imax, jmax, kmax, inb_flow, inb_scal
     use TLAB_VARS, only: imode_eqns, imode_sim
     use TLAB_VARS, only: itime, rtime

--- a/src/tools/dns/dns_local.f90
+++ b/src/tools/dns/dns_local.f90
@@ -3,6 +3,8 @@
 
 module DNS_LOCAL
     use TLAB_CONSTANTS, only: MAX_NSP, wp, wi, sp
+    USE TLAB_CONSTANTS, only: MAX_PATH_LENGTH
+    use TLAB_VARS, only: lfile
 #ifdef USE_PSFFT
     use NB3DFFT, only: NB3DFFT_SCHEDLTYPE
 #endif
@@ -22,8 +24,9 @@ module DNS_LOCAL
     real(wp) :: wall_time        ! Actual elapsed time during the simulation in seconds
 
     integer :: nitera_log           ! Iteration step for data logger with simulation information
-    character(len=*), parameter :: ofile = 'dns.out'    ! data logger filename
-    character(len=*), parameter :: vfile = 'dns.obs'    ! insitu obs. logger filename
+    character(len=*), parameter :: ofile_base = 'dns.out'    ! data logger filename
+    character(len=*), parameter :: vfile_base = 'dns.obs'    ! insitu obs. logger filename
+    character(len=MAX_PATH_LENGTH) :: ofile,vfile
     real(wp) :: logs_data(20)       ! information (time, time step, cfls, dilatation...)
     real(wp) :: obs_data(20)        ! information (custom variables / insitu measurements ...)
     integer  :: dns_obs_log
@@ -88,7 +91,8 @@ contains
 !########################################################################
 !########################################################################
     subroutine DNS_BOUNDS_CONTROL()
-        use TLAB_CONSTANTS, only: efile, lfile
+        use TLAB_CONSTANTS, only: efile
+        use TLAB_VARS, only: lfile
         use TLAB_VARS, only: imode_eqns, imode_ibm, stagger_on
         use TLAB_VARS, only: imax, jmax, kmax
         use TLAB_ARRAYS

--- a/src/tools/dns/dns_main.f90
+++ b/src/tools/dns/dns_main.f90
@@ -340,6 +340,9 @@ contains
         integer ip
         character(len=256) line1
 
+        ofile = TRIM(ADJUSTL(logger_path)) // TRIM(ADJUSTL(ofile_base))
+        ofile = TRIM(ADJUSTL(ofile))
+        
         line1 = '#'; ip = 1
         line1 = line1(1:ip)//' '//' Itn.'; ip = ip + 1 + 7
         line1 = line1(1:ip)//' '//' time'; ip = ip + 1 + 13
@@ -425,6 +428,9 @@ contains
         integer(wi)        :: ip, is
         character(len=256) :: line1
 
+        vfile = TRIM(ADJUSTL(logger_path)) // TRIM(ADJUSTL(vfile_base))
+        vfile = TRIM(ADJUSTL(vfile))
+        
         line1 = '#'; ip = 1
         line1 = line1(1:ip)//' '//' Itn.'; ip = ip + 1 + 7
         line1 = line1(1:ip)//' '//' time'; ip = ip + 1 + 13

--- a/src/tools/dns/dns_read_local.f90
+++ b/src/tools/dns/dns_read_local.f90
@@ -5,7 +5,7 @@
 subroutine DNS_READ_LOCAL(inifile)
 
     use TLAB_TYPES, only: MAX_MODES
-    use TLAB_CONSTANTS, only: wp, wi, big_wp, efile, lfile, wfile
+    use TLAB_CONSTANTS, only: wp, wi, big_wp, efile, wfile
     use TLAB_VARS
     use TLAB_PROCS
     use PARTICLE_VARS
@@ -448,7 +448,6 @@ subroutine DNS_READ_LOCAL(inifile)
     call TLAB_WRITE_ASCII(bakfile, '#[Statsitics]')
     call TLAB_WRITE_ASCII(bakfile, '#Averages=<yes/no>')
     call TLAB_WRITE_ASCII(bakfile, '#Pdfs=<yes/no>')
-    call TLAB_WRITE_ASCII(bakfile, '#ConditionalAverages=<yes/no>')
     call TLAB_WRITE_ASCII(bakfile, '#Intermittency=<yes/no>')
 
     call SCANINICHAR(bakfile, inifile, 'Statistics', 'Averages', 'yes', sRes)

--- a/src/tools/dns/dns_tower.f90
+++ b/src/tools/dns/dns_tower.f90
@@ -247,7 +247,7 @@ CONTAINS
        ip = 1+(tower_accumulation-1)*tower_jmax; ipm=ip+tower_jmax-1
 
        CALL TOWER_AVG_IK_V(imax,jmax,kmax,v(1,1,1,1),tower_pm(ip:ipm),wrk1d(6*jmax))
-    ! HANDLY FLOW FIELDS
+    ! HANDLE FLOW FIELDS
     ELSE IF ( index .EQ. 1 ) THEN
        DO kk=1,tower_kmax
           DO ii=1,tower_imax
@@ -305,6 +305,10 @@ CONTAINS
     USE MPI
     USE TLAB_MPI_VARS,   ONLY : ims_offset_i, ims_offset_j, ims_offset_k,ims_pro,ims_err
 #endif
+
+#ifdef USE_H5
+    USE HDF5
+#endif
     IMPLICIT NONE
 
 #ifdef USE_MPI
@@ -320,10 +324,22 @@ CONTAINS
 
     TINTEGER, POINTER :: tip
     TINTEGER :: itower,ktower,ip_skp,ip_srt,ip_end,tower_count,op_srt,op_end
+#ifdef USE_H5
+    INTEGER                                            :: h5_err
+    INTEGER(HID_T)                                     :: h5_avgFileID, h5_Space1ID, h5_Space2ID, h5_avgDsetID,h5_avgTsetID,h5_avgIsetID
+    INTEGER(HID_T)                                     :: h5_dID_loc
+    INTEGER(HID_T), DIMENSION(tower_imax,tower_kmax)   :: h5_fileID
+    INTEGER(HSIZE_T), DIMENSION(2)                     :: h5_varDim
+    CHARACTER(LEN=64),DIMENSION(5)                     :: vname
+    CHARACTER(LEN=64),DIMENSION(2)                     :: vname1d
+    CHARACTER(LEN=128) :: vname_loc
+#endif
+    TINTEGER :: i,include_global
+
     tip => tower_isize_plane
 
     IF ( tip .LT. 1 ) THEN
-       ! DO NOTHING
+       ! NOTHING TO DO FOR THIS TASK
     ELSE
 
        IF  ( itime .NE. INT(tower_it(nitera_save)+1)  )  THEN
@@ -332,77 +348,124 @@ CONTAINS
           !                          (But it should if the code is set-up properly)
        ENDIF
 
+#ifdef USE_H5
+       h5_varDim = (/tower_jmax,nitera_save/)
+       vname  = (/'u','v','w','p','s'/)
+       vname1d= (/'time','iter'/)
+
+       CALL h5open_f(h5_err)
+       CALL h5screate_simple_f(2_4,h5_vardim(1:2),h5_Space2ID,h5_err)
+       CALL h5screate_simple_f(1_4,h5_vardim(2:), h5_Space1ID,h5_err)
+
+       WRITE(cdummy,993) INT(tower_it(1))+1,itime
+993    FORMAT('tower.mean','.',I6.6,'-',I6.6,'.h5')
+       CALL h5fcreate_f(cdummy,H5F_ACC_TRUNC_F, h5_avgFileID, h5_err)
+       CALL h5dcreate_f(h5_avgFileID,vname1D(1), H5T_NATIVE_DOUBLE,  h5_Space1ID,h5_dID_loc,h5_err)
+       CALL h5dwrite_f (h5_dID_loc,H5T_NATIVE_DOUBLE, tower_t (1:nitera_save),h5_vardim(2:),h5_err)
+       CALL h5dcreate_f(h5_avgFileID,vname1D(2), H5T_NATIVE_INTEGER, h5_Space1ID,h5_dID_loc,h5_err)
+       CALL h5dwrite_f (h5_dID_loc,H5T_NATIVE_INTEGER,INT(tower_it(1:nitera_save)),h5_vardim(2:),h5_err)
+
+       DO itower=1,tower_imax
+          DO ktower=1,tower_kmax
+                WRITE(cdummy,994) &
+                     ims_offset_i+tower_ipos(itower), &
+                     ims_offset_k+tower_kpos(ktower),&
+                     INT(tower_it(1))+1,itime
+994             FORMAT('tower.',I6.6,'x',I6.6,'.',I6.6,'-',I6.6,'.h5')
+                CALL h5fcreate_f(cdummy,H5F_ACC_TRUNC_F, h5_fileID(itower,ktower), h5_err)
+          ENDDO
+       ENDDO
+#endif
        DO ivar=1,tower_varcount
           tower_count = 0
 #ifdef USE_MPI
           if ( ims_pro .EQ. 0 ) THEN
 #endif
-             op_srt=1; op_end=tower_jmax+2;
+#ifdef USE_H5
+             include_global=0
+#else
+             include_global=2
+#endif
+             op_srt=1; op_end=tower_jmax+include_global;
              ip_skp = tower_jmax*1;
              ip_srt = 1;
              ip_end = ip_srt + tower_jmax - 1;
 
              DO it=1,nitera_save
+#ifndef USE_H5
                 wrk3d(op_srt) =  tower_t(it)
                 wrk3d(op_srt+1)= tower_it(it)
+#endif
                 SELECT CASE(ivar)
                 CASE(1)
-                   wrk3d(op_srt+2:op_end) = tower_um(ip_srt:ip_end)
+                   wrk3d(op_srt+include_global:op_end) = tower_um(ip_srt:ip_end)
                 CASE(2)
-                   wrk3d(op_srt+2:op_end) = tower_vm(ip_srt:ip_end)
+                   wrk3d(op_srt+include_global:op_end) = tower_vm(ip_srt:ip_end)
                 CASE(3)
-                   wrk3d(op_srt+2:op_end) = tower_wm(ip_srt:ip_end)
+                   wrk3d(op_srt+include_global:op_end) = tower_wm(ip_srt:ip_end)
                 CASE(4)
-                   wrk3d(op_srt+2:op_end) = tower_pm(ip_srt:ip_end)
+                   wrk3d(op_srt+include_global:op_end) = tower_pm(ip_srt:ip_end)
                 CASE(5)
-                   wrk3d(op_srt+2:op_end) = tower_sm(ip_srt:ip_end)
+                   wrk3d(op_srt+include_global:op_end) = tower_sm(ip_srt:ip_end)
                 CASE DEFAULT
                    ! ISSUE WARNING - NO MORE THAN ONE SCALAR
                 END SELECT
-                ip_srt = ip_srt + ip_skp; op_srt = op_srt + tower_jmax+2
-                ip_end = ip_end + ip_skp; op_end = op_end + tower_jmax+2
+                ip_srt = ip_srt + ip_skp; op_srt = op_srt + tower_jmax+include_global
+                ip_end = ip_end + ip_skp; op_end = op_end + tower_jmax+include_global
              ENDDO
-
+#ifdef USE_H5
+             ! IMPLICIT Type casting -- saving the variable as real, but passing double values (see below)
+             CALL h5dcreate_f(h5_avgFileID,vname(ivar),H5T_NATIVE_REAL,h5_space2ID,h5_avgDsetID,h5_err)
+             CALL h5dwrite_f(h5_avgDsetID,             H5T_NATIVE_DOUBLE,wrk3d(1:tower_jmax*nitera_save),h5_vardim,h5_err)
+#else
              WRITE(cdummy,995) &
                   INT(tower_it(1))+1,itime,ivar
 995          FORMAT('tower.mean','.',I6.6,'-',I6.6,'.',I1)
              OPEN(73,FILE=TRIM(ADJUSTL(cdummy)),ACCESS='STREAM', FORM='UNFORMATTED')
              WRITE(73,POS=1) wrk3d(1:nitera_save*(tower_jmax+2))
              CLOSE(73)
-
+#endif
 #ifdef USE_MPI
           ENDIF
 #endif
 
-          DO itower=1,tower_imax
-             DO ktower=1,tower_kmax
+          DO itower=1, tower_imax
+             DO ktower=1, tower_kmax
+#ifdef USE_H5
+                include_global=0
+#else
+                include_global=2
+#endif
                 ip_skp = tower_jmax*tip;
                 ip_srt = tower_count*tower_jmax + 1;
                 ip_end = ip_srt + tower_jmax - 1;
-                op_srt=1; op_end=tower_jmax+2;
-
+                op_srt=1; op_end=tower_jmax+include_global;
                 DO it=1,nitera_save
+#ifndef USE_H5
                    wrk3d(op_srt) =  tower_t(it)
                    wrk3d(op_srt+1)= tower_it(it)
+#endif
                    SELECT CASE(ivar)
                    CASE(1)
-                      wrk3d(op_srt+2:op_end) = tower_u(ip_srt:ip_end)
+                      wrk3d(op_srt+include_global:op_end) = tower_u(ip_srt:ip_end)
                    CASE(2)
-                      wrk3d(op_srt+2:op_end) = tower_v(ip_srt:ip_end)
+                      wrk3d(op_srt+include_global:op_end) = tower_v(ip_srt:ip_end)
                    CASE(3)
-                      wrk3d(op_srt+2:op_end) = tower_w(ip_srt:ip_end)
+                      wrk3d(op_srt+include_global:op_end) = tower_w(ip_srt:ip_end)
                    CASE(4)
-                      wrk3d(op_srt+2:op_end) = tower_p(ip_srt:ip_end)
+                      wrk3d(op_srt+include_global:op_end) = tower_p(ip_srt:ip_end)
                    CASE(5)
-                      wrk3d(op_srt+2:op_end) = tower_s(ip_srt:ip_end)
+                      wrk3d(op_srt+include_global:op_end) = tower_s(ip_srt:ip_end)
                    CASE DEFAULT
-                      ! ISSUE WARNING - NO MORE THAN ONE SCALAR
+                      ! COULD ISSUE WARNING SOMEWHERE - NO MORE THAN ONE SCALAR FOR TOWERS
                    END SELECT
-                   ip_srt = ip_srt + ip_skp; op_srt = op_srt + tower_jmax+2
-                   ip_end = ip_end + ip_skp; op_end = op_end + tower_jmax+2
+                   ip_srt = ip_srt + ip_skp; op_srt = op_srt + tower_jmax+include_global
+                   ip_end = ip_end + ip_skp; op_end = op_end + tower_jmax+include_global
                 ENDDO
-                tower_count = tower_count + 1
-
+#ifdef USE_H5
+                CALL h5dcreate_f(h5_fileID(itower,ktower),vname(ivar),H5T_NATIVE_REAL,h5_Space2ID,h5_dID_loc,h5_err)
+                CALL h5dwrite_f(h5_dID_loc,H5T_NATIVE_DOUBLE,wrk3d(1:tower_jmax*nitera_save),h5_vardim,h5_err)
+#else
                 WRITE(cdummy,997) &
                      ims_offset_i+tower_ipos(itower), &
                      ims_offset_k+tower_kpos(ktower),&
@@ -411,15 +474,25 @@ CONTAINS
                 OPEN(73,FILE=TRIM(ADJUSTL(cdummy)),ACCESS='STREAM', FORM='UNFORMATTED')
                 WRITE(73,POS=1) wrk3d(1:nitera_save*(tower_jmax+2))
                 CLOSE(73)
+#endif
+                tower_count = tower_count + 1
              ENDDO
           ENDDO
        ENDDO
+
+#ifdef USE_H5
+       CALL h5fclose_f(h5_avgFileID,h5_err)
+       DO itower=1,tower_imax
+          DO ktower=1,tower_kmax
+             CALL h5fclose_f(h5_fileID(itower,ktower), h5_err)
+          ENDDO
+       ENDDO
+       CALL h5close_f(h5_err)
+#endif
     ENDIF
     tower_accumulation = 1
 
   END SUBROUTINE DNS_TOWER_WRITE
-
-
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !

--- a/src/tools/dns/particle_trajectories.f90
+++ b/src/tools/dns/particle_trajectories.f90
@@ -5,7 +5,8 @@
 
 module PARTICLE_TRAJECTORIES
 
-    use TLAB_CONSTANTS, only: efile, lfile, wp, sp, wi, longi, sizeofint
+    use TLAB_CONSTANTS, only: efile, wp, sp, wi, longi, sizeofint
+    use TLAB_VARS, only: lfile
     use PARTICLE_VARS
     use TLAB_PROCS
     use DNS_LOCAL, only: nitera_save

--- a/src/tools/dns/planes.f90
+++ b/src/tools/dns/planes.f90
@@ -2,7 +2,8 @@
 #include "dns_error.h"
 
 module PLANES
-    use TLAB_CONSTANTS, only: lfile, efile, wp, wi, fmt_r, small_wp
+    use TLAB_CONSTANTS, only: efile, wp, wi, fmt_r, small_wp
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: imax, jmax, kmax, inb_scal_array, inb_flow_array, inb_txc
     use TLAB_VARS, only: g, imode_ibm, scal_on
     use TLAB_VARS, only: itime, rtime

--- a/src/tools/dns/rhs_global_incompressible_nbc.f90
+++ b/src/tools/dns/rhs_global_incompressible_nbc.f90
@@ -17,8 +17,9 @@ subroutine RHS_GLOBAL_INCOMPRESSIBLE_NBC(u, v, w, s, &
 
     use OMP_LIB, only: omp_get_thread_num
 
-    use TLAB_CONSTANTS, only: lfile, wfile, efile, tfile
+    use TLAB_CONSTANTS, only: wfile, efile, tfile
     !
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: g
     use TLAB_VARS, only: imode_eqns
     use TLAB_VARS, only: inb_flow, inb_scal, inb_scal_array

--- a/src/tools/initialize/flow/flow_local.f90
+++ b/src/tools/initialize/flow/flow_local.f90
@@ -2,8 +2,9 @@
 #include "dns_error.h"
 
 module FLOW_LOCAL
-    use TLAB_CONSTANTS, only: efile, lfile, wp, wi, pi_wp
+    use TLAB_CONSTANTS, only: efile, wp, wi, pi_wp
     use TLAB_TYPES, only: profiles_dt, discrete_dt
+    USE TLAB_VARS, only: lfile
     use TLAB_VARS, only: imax, jmax, kmax, isize_field
     use TLAB_VARS, only: g, qbg, tbg, hbg
     use TLAB_POINTERS_3D, only: p_wrk1d, p_wrk2d

--- a/src/tools/initialize/grid/grid_main.f90
+++ b/src/tools/initialize/grid/grid_main.f90
@@ -5,7 +5,8 @@
 
 program INIGRID
     use TLAB_TYPES, only: grid_dt, wp
-    use TLAB_CONSTANTS, only: gfile, ifile, lfile, efile
+    use TLAB_CONSTANTS, only: gfile, ifile, efile
+    use TLAB_VARS, only: lfile
     use TLAB_PROCS
     use GRID_LOCAL
 #ifdef USE_MPI

--- a/src/tools/initialize/rand/rand_read_local.f90
+++ b/src/tools/initialize/rand/rand_read_local.f90
@@ -1,7 +1,8 @@
 #include "dns_error.h"
 
 subroutine RAND_READ_LOCAL(inifile)
-    use TLAB_CONSTANTS, only: efile, lfile
+    use TLAB_CONSTANTS, only: efile
+    use TLAB_VARS, only: lfile
     use TLAB_PROCS
     use RAND_LOCAL
 

--- a/src/tools/initialize/scal/scal_read_local.f90
+++ b/src/tools/initialize/scal/scal_read_local.f90
@@ -3,7 +3,8 @@
 
 subroutine SCAL_READ_LOCAL(inifile)
 
-    use TLAB_CONSTANTS, only: wp, wi, efile, lfile, wfile, MAX_NSP
+    use TLAB_CONSTANTS, only: wp, wi, efile, wfile, MAX_NSP
+    use TLAB_VARS, only: lfile
     use TLAB_VARS, only: inb_scal
     use TLAB_VARS, only: sbg
     use TLAB_PROCS

--- a/src/tools/statistics/averages.f90
+++ b/src/tools/statistics/averages.f90
@@ -210,7 +210,6 @@ program AVERAGES
         iread_flow = .true.; iread_scal = .true.; inb_txc = max(inb_txc, 6)
     case (8)
         nfield = 3
-
         iread_flow = .true.; inb_txc = max(inb_txc, 6)
     case (9)
         nfield = 5

--- a/src/tools/statistics/pdfs.f90
+++ b/src/tools/statistics/pdfs.f90
@@ -7,7 +7,7 @@
 program PDFS
 
     use TLAB_TYPES, only: pointers_dt
-    use TLAB_CONSTANTS, only: ifile, efile, lfile, gfile, tag_flow, tag_scal, wp
+    use TLAB_CONSTANTS, only: ifile, efile, gfile, tag_flow, tag_scal, wp
     use TLAB_VARS
     use TLAB_ARRAYS
     use TLAB_PROCS

--- a/src/tools/statistics/spectra_pool.f90
+++ b/src/tools/statistics/spectra_pool.f90
@@ -371,7 +371,7 @@ end subroutine RADIAL_SAMPLESIZE
 !########################################################################
 subroutine WRITE_SPECTRUM1D(fname, varname, nxy, nvar, pow)
 
-    use TLAB_CONSTANTS, only: lfile
+    use TLAB_VARS, only: lfile
     use TLAB_PROCS
 #ifdef USE_MPI
     use TLAB_MPI_VARS, only: ims_pro


### PR DESCRIPTION
1. IO_NOFile in IBM-module
2. dns.<out,log,obs> can be written to another directory (e.g. $HOME) to avoid frequent IO on the working directory (we had lustre problems on the cluster because of this)
3. dns.nqs-hawk is changed according to write the logger-files to HOME and copy them afterwards back
4. Option to write Towers to HDF5 in Serial mode (parallel missing)

